### PR TITLE
RavenDB-20137 - Invalid query results when using paging / different results on different nodes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.54004</Version>
-    <FileVersion>3.0.54004.0</FileVersion>
+    <Version>3.0.54005</Version>
+    <FileVersion>3.0.54005.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Index/TermBuffer.cs
+++ b/src/Lucene.Net/Index/TermBuffer.cs
@@ -24,7 +24,7 @@ using UnicodeUtil = Lucene.Net.Util.UnicodeUtil;
 namespace Lucene.Net.Index
 {
 	
-	sealed class TermBuffer : System.ICloneable
+	public sealed class TermBuffer : System.ICloneable
 	{
 		
 		private System.String field;

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -824,7 +824,7 @@ namespace Lucene.Net.Search
                         else
                         {
                             // the term was deleted but we must preserve the order in the array (it must match the termNumber)
-                            mterms.AddEmpty();
+                            mterms.AddEmpty(termEnum.termBuffer);
                         }
 
                         termNumber++;

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -215,6 +215,8 @@ namespace Lucene.Net.Util
 
         public void AddEmpty()
         {
+            // since we are doing a binary search, we must keep the order of the terms
+            _strings[_index].Start = _index > 0 ? _strings[_index - 1].Start : null;
             _index++;
         }
 

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using Lucene.Net.Index;
 
 namespace Lucene.Net.Util
 {
@@ -213,10 +214,18 @@ namespace Lucene.Net.Util
             _index++;
         }
 
-        public void AddEmpty()
+        public void AddEmpty(TermBuffer termBuffer)
         {
             // since we are doing a binary search, we must keep the order of the terms
-            _strings[_index].Start = _index > 0 ? _strings[_index - 1].Start : null;
+
+            if (_index == 0)
+            {
+                // we must allocate the first one
+                Add(termBuffer.TextAsSpan);
+                return;
+            }
+
+            _strings[_index].Start = _strings[_index - 1].Start;
             _index++;
         }
 


### PR DESCRIPTION
Since we are doing a binary search, we must preserve the order of the terms.
Since we have a term that we don't want to allocate and in order to preserve the order, we are going to use the previous term.