### PR TITLE
RavenDB-20565 - allow the caller of PurgeAllCaches to dispose the old StringIndexCache

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.54007</Version>
-    <FileVersion>3.0.54007.0</FileVersion>
+    <Version>3.0.54008</Version>
+    <FileVersion>3.0.54008.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -659,7 +659,7 @@ namespace Lucene.Net.Search
         /// of Lucene.
         /// <p/>
         /// </summary>
-        void PurgeAllCaches();
+        IDisposable PurgeAllCaches();
 
         /// <summary>
         /// Expert: drops all cache entries associated with this

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -61,7 +61,8 @@ namespace Lucene.Net.Search
         {
             Init();
         }
-        private void  Init()
+
+        private void Init()
         {
             _byteCache = new ByteCache(this);
             _shortCache = new ShortCache(this);
@@ -73,11 +74,17 @@ namespace Lucene.Net.Search
             _stringIndexCache = new StringIndexCache(this);
         }
 
-        public virtual void  PurgeAllCaches()
+        public virtual IDisposable PurgeAllCaches()
         {
             lock (this)
             {
+                // PurgeAllCaches is replacing the cache with a new one (without actually releasing any memory).
+                // When the GC will run, the finalizer of the Segments will be executed and release the unmanaged memory.
+                // We'll return the old StringIndexCache and let the caller decide if he wants to dispose it sooner
+
+                var copy = _stringIndexCache;
                 Init();
+                return copy;
             }
         }
 
@@ -768,7 +775,7 @@ namespace Lucene.Net.Search
             return _stringIndexCache.Get(reader, new Entry(field, (Parser) null), state);
         }
         
-        internal sealed class StringIndexCache:Cache<StringIndex>
+        internal sealed class StringIndexCache : Cache<StringIndex>, IDisposable
         {
             internal StringIndexCache(FieldCache wrapper):base(wrapper)
             {
@@ -839,6 +846,20 @@ namespace Lucene.Net.Search
 
                 StringIndex value_Renamed = new StringIndex(retArray, retArrayOrdered, mterms);
                 return value_Renamed;
+            }
+
+            public void Dispose()
+            {
+                foreach (var keyValue in readerCache)
+                {
+                    foreach (var keyValuePair in keyValue.Value)
+                    {
+                        if (keyValuePair.Value is StringIndex si)
+                        {
+                            si.lookup.Dispose();
+                        }
+                    }
+                }
             }
         }
         

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -7,7 +7,7 @@ using Lucene.Net.Index;
 
 namespace Lucene.Net.Util
 {
-    public unsafe class UnmanagedStringArray
+    public unsafe class UnmanagedStringArray : IDisposable
     {
         public class Segment : IDisposable
         {
@@ -233,6 +233,16 @@ namespace Lucene.Net.Util
         {
             get => _strings[position];
             set => _strings[position] = value;
+        }
+
+        public void Dispose()
+        {
+            foreach (var segment in _segments)
+            {
+                segment.Dispose();
+            }
+
+            _segments.Clear();
         }
     }
 }

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -72,7 +72,7 @@ namespace Lucene.Net.Util
             
             public override string ToString()
             {
-                return Encoding.UTF8.GetString(StringAsBytes.ToArray());
+                return Encoding.UTF8.GetString(StringAsBytes);
             }
 
             public static int CompareOrdinal(UnmanagedString strA, UnmanagedString strB)


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-20565/AccessViolationException-for-a-query-with-order-by