### PR TITLE
RavenDB-20700 - Use a single cache per segment

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.54008</Version>
-    <FileVersion>3.0.54008.0</FileVersion>
+    <Version>3.0.54009</Version>
+    <FileVersion>3.0.54009.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Buffers;
+using System.Threading;
+using Lucene.Net.Store;
+
+namespace Lucene.Net.Index
+{
+    public class ArrayHolder : IDisposable
+    {
+        private readonly int _size;
+        private readonly Directory _directory;
+        private readonly string _name;
+        private readonly long[] _longArray;
+        private readonly Term[] _termArray;
+        private readonly TermInfo[] _termInfoArray;
+        private int _usages;
+
+        public Span<long> LongArray => _longArray.AsSpan(0, _size);
+        public Span<TermInfo> InfoArray => _termInfoArray.AsSpan(0, _size);
+        public Span<Term> IndexTerms => _termArray.AsSpan(0, _size);
+
+        public ArrayHolder(int size, Directory directory, string name)
+        {
+            _size = size;
+            _directory = directory;
+            _name = name;
+            _longArray = ArrayPool<long>.Shared.Rent(size);
+            _termArray = ArrayPool<Term>.Shared.Rent(size);
+            _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
+        }
+
+        public void AddRef()
+        {
+            Interlocked.Increment(ref _usages);
+        }
+
+        public void ReleaseRef()
+        {
+            if (Interlocked.Decrement(ref _usages) == 0)
+                _directory.RemoveFromTermsIndexCache(_name);
+        }
+
+        public static ArrayHolder GenerateArrayHolder(Directory directory, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        {
+            var indexEnum = new SegmentTermEnum(directory.OpenInput(name, readBufferSize, state), fieldInfos, true, state);
+
+            try
+            {
+                int indexSize = 1 + ((int)indexEnum.size - 1) / indexDivisor; // otherwise read index
+
+                var holder = new ArrayHolder(indexSize, directory, name);
+
+                for (int i = 0; indexEnum.Next(state); i++)
+                {
+                    holder.IndexTerms[i] = indexEnum.Term;
+                    holder.InfoArray[i] = indexEnum.TermInfo();
+                    holder.LongArray[i] = indexEnum.indexPointer;
+
+                    for (int j = 1; j < indexDivisor; j++)
+                        if (!indexEnum.Next(state))
+                            break;
+                }
+
+                return holder;
+
+            }
+            finally
+            {
+                indexEnum?.Close();
+            }
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+
+            if (_size > 256 * 1024)
+                return;
+
+            if (_longArray != null)
+                ArrayPool<long>.Shared.Return(_longArray);
+
+            if (_termArray != null)
+                ArrayPool<Term>.Shared.Return(_termArray, clearArray: true);
+
+            if (_termInfoArray != null)
+                ArrayPool<TermInfo>.Shared.Return(_termInfoArray);
+        }
+
+        ~ArrayHolder()
+        {
+            Dispose();
+        }
+    }
+}

--- a/src/Lucene.Net/Index/CompoundFileReader.cs
+++ b/src/Lucene.Net/Index/CompoundFileReader.cs
@@ -166,7 +166,17 @@ namespace Lucene.Net.Index
 				return new CSIndexInput(stream, entry.offset, entry.length, readBufferSize, state);
 			}
 		}
-		
+
+        public override ArrayHolder GetCache(Directory _, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        {
+            return directory.GetCache(this, name, fieldInfos, readBufferSize, indexDivisor, state);
+        }
+
+        public override void RemoveFromTermsIndexCache(string name)
+        {
+            directory.RemoveFromTermsIndexCache(name);
+        }
+
 		/// <summary>Returns an array of strings, one for each file in the directory. </summary>
 		public override System.String[] ListAll(IState state)
 		{

--- a/src/Lucene.Net/Index/CompoundFileReader.cs
+++ b/src/Lucene.Net/Index/CompoundFileReader.cs
@@ -167,7 +167,7 @@ namespace Lucene.Net.Index
 			}
 		}
 
-        public override ArrayHolder GetCache(Directory _, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        public override ArrayHolder GetCache(string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
         {
             return directory.GetCache(this, name, fieldInfos, readBufferSize, indexDivisor, state);
         }

--- a/src/Lucene.Net/Index/TermInfo.cs
+++ b/src/Lucene.Net/Index/TermInfo.cs
@@ -22,7 +22,7 @@ namespace Lucene.Net.Index
 	
 	/// <summary>A TermInfo is the record of information stored for a term.</summary>
 	
-	struct TermInfo
+	public struct TermInfo
 	{
 		/// <summary>The number of documents which contain the term. </summary>
 		internal int docFreq;

--- a/src/Lucene.Net/Index/TermInfosReader.cs
+++ b/src/Lucene.Net/Index/TermInfosReader.cs
@@ -16,7 +16,6 @@
  */
 
 using System;
-using System.Buffers;
 using Lucene.Net.Store;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
@@ -25,13 +24,12 @@ using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Index
 {
-
     /// <summary>This stores a monotonically increasing set of &lt;Term, TermInfo&gt; pairs in a
-	/// Directory.  Pairs are accessed either by Term or by ordinal position the
-	/// set.  
-	/// </summary>
-	
-	sealed class TermInfosReader : IDisposable
+    /// Directory.  Pairs are accessed either by Term or by ordinal position the
+    /// set.  
+    /// </summary>
+
+    sealed class TermInfosReader : IDisposable
 	{
 		private readonly Directory directory;
 		private readonly String segment;
@@ -43,9 +41,9 @@ namespace Lucene.Net.Index
 		private readonly SegmentTermEnum origEnum;
 		private readonly long size;
 		
-		private Span<Term> indexTerms => _holder.IndexTerms;
-		private Span<TermInfo> indexInfos => _holder.InfoArray;
-		private Span<long> indexPointers =>_holder.LongArray;
+		private Span<Term> indexTerms => _termsIndexCache.IndexTerms;
+		private Span<TermInfo> indexInfos => _termsIndexCache.InfoArray;
+		private Span<long> indexPointers =>_termsIndexCache.LongArray;
 		
 		private readonly int totalIndexInterval;
 		
@@ -77,49 +75,7 @@ namespace Lucene.Net.Index
 	        }
 	    }
 
-        private class ArrayHolder : IDisposable
-        {
-            private readonly int _size;
-            private readonly long[] _longArray;
-            private readonly Term[] _termArray;
-            private readonly TermInfo[] _termInfoArray;
-
-            public ArrayHolder(int size)
-            {
-                _size = size;
-                _longArray = ArrayPool<long>.Shared.Rent(size);
-                _termArray = ArrayPool<Term>.Shared.Rent(size);
-                _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
-            }
-
-            public Span<long> LongArray => _longArray.AsSpan(0, _size);
-            public Span<TermInfo> InfoArray => _termInfoArray.AsSpan(0, _size);
-            public Span<Term> IndexTerms => _termArray.AsSpan(0, _size);
-
-            public void Dispose()
-            {
-                GC.SuppressFinalize(this);
-
-                if (_longArray != null)
-                    ArrayPool<long>.Shared.Return(_longArray);
-
-                if (_termArray != null)
-                    ArrayPool<Term>.Shared.Return(_termArray, clearArray: true);
-
-                if (_termInfoArray != null)
-                    ArrayPool<TermInfo>.Shared.Return(_termInfoArray);
-            }
-
-            ~ArrayHolder()
-            {
-				#if DEBUG
-                Console.WriteLine("Array holder is leaking...");
-				#endif
-				Dispose();
-            }
-        }
-
-        private readonly ArrayHolder _holder;
+        private readonly ArrayHolder _termsIndexCache;
 
         private readonly DoubleBarrelLRUCache<CloneableTerm, TermInfo> termInfoCache = new DoubleBarrelLRUCache<CloneableTerm, TermInfo>(DEFAULT_CACHE_SIZE);
 
@@ -146,41 +102,18 @@ namespace Lucene.Net.Index
 				
 				origEnum = new SegmentTermEnum(directory.OpenInput(segment + "." + IndexFileNames.TERMS_EXTENSION, readBufferSize, state), fieldInfos, false, state);
 				size = origEnum.size;
-				
+
 				if (indexDivisor != - 1)
 				{
 					// Load terms index
 					totalIndexInterval = origEnum.indexInterval * indexDivisor;
-					var indexEnum = new SegmentTermEnum(directory.OpenInput(segment + "." + IndexFileNames.TERMS_INDEX_EXTENSION, readBufferSize, state), fieldInfos, true, state);
-					
-					try
-					{
-						int indexSize = 1 + ((int) indexEnum.size - 1) / indexDivisor; // otherwise read index
-						
-                        _holder?.Dispose();
-                        _holder = new ArrayHolder(indexSize);
-						
-						for (int i = 0; indexEnum.Next(state); i++)
-						{
-							indexTerms[i] = indexEnum.Term;
-							indexInfos[i] = indexEnum.TermInfo();
-							indexPointers[i] = indexEnum.indexPointer;
-							
-							for (int j = 1; j < indexDivisor; j++)
-								if (!indexEnum.Next(state))
-									break;
-						}
-					}
-					finally
-					{
-						indexEnum.Close();
-					}
-				}
+                    _termsIndexCache = directory.GetCache(directory, segment + "." + IndexFileNames.TERMS_INDEX_EXTENSION, fieldInfos, readBufferSize, indexDivisor, state);
+					_termsIndexCache.AddRef();
+                }
 				else
 				{
 					// Do not load terms index:
 					totalIndexInterval = - 1;
-                    _holder?.Dispose();
 				}
 				success = true;
 			}
@@ -216,7 +149,10 @@ namespace Lucene.Net.Index
             if (origEnum != null)
                 origEnum.Dispose();
             threadResources.Dispose();
-            _holder?.Dispose();
+
+            _termsIndexCache?.ReleaseRef();
+			// not disposing the cache here, since it might be still in use
+            //_termsIndexCache?.Dispose();
 
             isDisposed = true;
         }

--- a/src/Lucene.Net/Index/TermInfosReader.cs
+++ b/src/Lucene.Net/Index/TermInfosReader.cs
@@ -107,7 +107,7 @@ namespace Lucene.Net.Index
 				{
 					// Load terms index
 					totalIndexInterval = origEnum.indexInterval * indexDivisor;
-                    _termsIndexCache = directory.GetCache(directory, segment + "." + IndexFileNames.TERMS_INDEX_EXTENSION, fieldInfos, readBufferSize, indexDivisor, state);
+                    _termsIndexCache = directory.GetCache(segment + "." + IndexFileNames.TERMS_INDEX_EXTENSION, fieldInfos, readBufferSize, indexDivisor, state);
 					_termsIndexCache.AddRef();
                 }
 				else

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -17,7 +17,9 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Runtime.Serialization;
+using Lucene.Net.Index;
 using IndexFileNameFilter = Lucene.Net.Index.IndexFileNameFilter;
 
 namespace Lucene.Net.Store
@@ -43,6 +45,9 @@ namespace Lucene.Net.Store
         [Serializable]
     public abstract class Directory : System.IDisposable
 	{
+        [NonSerialized]
+        private ConcurrentDictionary<string, Lazy<ArrayHolder>> _termsIndexCachePerSegment = new ConcurrentDictionary<string, Lazy<ArrayHolder>>();
+
 		protected internal volatile bool isOpen = true;
 		
 		/// <summary>Holds the LockFactory instance (implements locking for
@@ -99,7 +104,22 @@ namespace Lucene.Net.Store
 		{
 			return OpenInput(name, state);
 		}
-		
+
+        public virtual ArrayHolder GetCache(Directory directory, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        {
+            var lazyArrayHolder = _termsIndexCachePerSegment.GetOrAdd(name,
+                new Lazy<ArrayHolder>(() => ArrayHolder.GenerateArrayHolder(directory, name, fieldInfos, readBufferSize, indexDivisor, state)));
+
+            return lazyArrayHolder.Value;
+        }
+
+        public virtual void RemoveFromTermsIndexCache(string name)
+        {
+            _termsIndexCachePerSegment.TryRemove(name, out _);
+            // intentionally not disposing the cache here since it might be in use by a TemInfosReader instance.
+            // we'll let the finalizer clean it when it isn't in use anymore.
+        }
+
 		/// <summary>Construct a <see cref="Lock" />.</summary>
 		/// <param name="name">the name of the lock file
 		/// </param>
@@ -133,7 +153,13 @@ namespace Lucene.Net.Store
             Dispose(true);
         }
 
-	    protected abstract void Dispose(bool disposing);
+        protected virtual void Dispose(bool disposing)
+        {
+            foreach ((_, Lazy<ArrayHolder> cacheLazy) in _termsIndexCachePerSegment)
+            {
+                cacheLazy.Value.Dispose();
+            }
+        }
 
 	    /// <summary> Set the LockFactory that this Directory instance should
 		/// use for its locking implementation.  Each * instance of
@@ -265,5 +291,11 @@ namespace Lucene.Net.Store
 
         [NonSerialized]
         internal ArrayPool<byte> ByteBlockPool = ArrayPool<byte>.Create();
+
+		[OnDeserialized]
+        public void OnDeserialized(StreamingContext _)
+        {
+            _termsIndexCachePerSegment = new ConcurrentDictionary<string, Lazy<ArrayHolder>>();
+        }
     }
 }

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -105,7 +105,12 @@ namespace Lucene.Net.Store
 			return OpenInput(name, state);
 		}
 
-        public virtual ArrayHolder GetCache(Directory directory, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        public virtual ArrayHolder GetCache(string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
+        {
+            return GetCache(this, name, fieldInfos, readBufferSize, indexDivisor, state);
+        }
+
+        public ArrayHolder GetCache(Directory directory, string name, FieldInfos fieldInfos, int readBufferSize, int indexDivisor, IState state)
         {
             var lazyArrayHolder = _termsIndexCachePerSegment.GetOrAdd(name,
                 new Lazy<ArrayHolder>(() => ArrayHolder.GenerateArrayHolder(directory, name, fieldInfos, readBufferSize, indexDivisor, state)));


### PR DESCRIPTION
We keep a cache per each segment, for the `IndexWriter` (indexing thread) and for the `IndexReader` (can be multiple readers).
The segments are immutable so the cache for the same segment will be identical.