### PR TITLE
RavenDB-23220 - Use unmanaged string array instead of strings to reduce GC pressure

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.54012</Version>
-    <FileVersion>3.0.54012.0</FileVersion>
+    <Version>3.0.54013</Version>
+    <FileVersion>3.0.54013.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -11,14 +11,15 @@ namespace Lucene.Net.Index
         private readonly Directory _directory;
         private readonly string _name;
         private readonly long[] _longArray;
-        private readonly Term[] _termArray;
         private readonly TermInfo[] _termInfoArray;
+        private readonly UnmanagedIndexTerms _unmanagedIndexTerms;
+
         private int _usages;
         private long _managedAllocations;
 
         public Span<long> LongArray => _longArray.AsSpan(0, _size);
         public Span<TermInfo> InfoArray => _termInfoArray.AsSpan(0, _size);
-        public Span<Term> IndexTerms => _termArray.AsSpan(0, _size);
+        public UnmanagedIndexTerms UnmanagedIndexTerms => _unmanagedIndexTerms;
 
         public static Action<long> OnArrayHolderCreated;
 
@@ -30,7 +31,7 @@ namespace Lucene.Net.Index
             _directory = directory;
             _name = name;
             _longArray = ArrayPool<long>.Shared.Rent(size);
-            _termArray = ArrayPool<Term>.Shared.Rent(size);
+            _unmanagedIndexTerms = new UnmanagedIndexTerms(size);
             _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
         }
 
@@ -59,7 +60,7 @@ namespace Lucene.Net.Index
 
                 for (int i = 0; indexEnum.Next(state); i++)
                 {
-                    holder.IndexTerms[i] = indexEnum.Term;
+                    holder.UnmanagedIndexTerms.Add(i, indexEnum.Field, indexEnum.TextAsSpan);
                     holder.InfoArray[i] = indexEnum.TermInfo();
                     holder.LongArray[i] = indexEnum.indexPointer;
 
@@ -88,14 +89,13 @@ namespace Lucene.Net.Index
 
             OnArrayHolderDisposed?.Invoke(_managedAllocations);
 
+            _unmanagedIndexTerms?.Dispose();
+
             if (_size > 256 * 1024)
                 return;
 
             if (_longArray != null)
                 ArrayPool<long>.Shared.Return(_longArray);
-
-            if (_termArray != null)
-                ArrayPool<Term>.Shared.Return(_termArray, clearArray: true);
 
             if (_termInfoArray != null)
                 ArrayPool<TermInfo>.Shared.Return(_termInfoArray);

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -26,7 +26,7 @@ namespace Lucene.Net.Index
 
         public static Action<long> OnArrayHolderDisposed;
 
-        public const int MaxSizeToTakeFromArrayPool = 128 * 1024;
+        public const int ArrayPoolThreshold = 128 * 1024;
 
         public ArrayHolder(int size, Directory directory, string name)
         {
@@ -34,7 +34,7 @@ namespace Lucene.Net.Index
             _directory = directory;
             _name = name;
 
-            if (size > MaxSizeToTakeFromArrayPool)
+            if (size > ArrayPoolThreshold)
             {
                 _longArray = new long[size];
                 _termInfoArray = new TermInfo[size];
@@ -102,7 +102,7 @@ namespace Lucene.Net.Index
 
             _unmanagedIndexTerms?.Dispose();
 
-            if (_size > MaxSizeToTakeFromArrayPool)
+            if (_size > ArrayPoolThreshold)
                 return;
 
             if (_longArray != null)

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -20,19 +20,31 @@ namespace Lucene.Net.Index
         public Span<long> LongArray => _longArray.AsSpan(0, _size);
         public Span<TermInfo> InfoArray => _termInfoArray.AsSpan(0, _size);
         public UnmanagedIndexTerms UnmanagedIndexTerms => _unmanagedIndexTerms;
-        public int ActualLongArraySize => _longArray.Length;
+        public int ActualArraySize => _longArray.Length;
 
         public static Action<long> OnArrayHolderCreated;
 
         public static Action<long> OnArrayHolderDisposed;
+
+        public const int MaxSizeToTakeFromArrayPool = 128 * 1024;
 
         public ArrayHolder(int size, Directory directory, string name)
         {
             _size = size;
             _directory = directory;
             _name = name;
-            _longArray = ArrayPool<long>.Shared.Rent(size);
-            _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
+
+            if (size > MaxSizeToTakeFromArrayPool)
+            {
+                _longArray = new long[size];
+                _termInfoArray = new TermInfo[size];
+            }
+            else
+            {
+                _longArray = ArrayPool<long>.Shared.Rent(size);
+                _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
+            }
+
             _unmanagedIndexTerms = new UnmanagedIndexTerms(size);
         }
 
@@ -68,7 +80,7 @@ namespace Lucene.Net.Index
                             break;
                 }
 
-                holder._managedAllocations = (holder.ActualLongArraySize * (TermInfo.SizeOf + sizeof(long)));
+                holder._managedAllocations = (holder.ActualArraySize * (TermInfo.SizeOf + sizeof(long)));
 
                 OnArrayHolderCreated?.Invoke(holder._managedAllocations);
 
@@ -90,7 +102,7 @@ namespace Lucene.Net.Index
 
             _unmanagedIndexTerms?.Dispose();
 
-            if (_size > 256 * 1024)
+            if (_size > MaxSizeToTakeFromArrayPool)
                 return;
 
             if (_longArray != null)

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -20,6 +20,7 @@ namespace Lucene.Net.Index
         public Span<long> LongArray => _longArray.AsSpan(0, _size);
         public Span<TermInfo> InfoArray => _termInfoArray.AsSpan(0, _size);
         public UnmanagedIndexTerms UnmanagedIndexTerms => _unmanagedIndexTerms;
+        public int ActualLongArraySize => _longArray.Length;
 
         public static Action<long> OnArrayHolderCreated;
 
@@ -31,8 +32,8 @@ namespace Lucene.Net.Index
             _directory = directory;
             _name = name;
             _longArray = ArrayPool<long>.Shared.Rent(size);
-            _unmanagedIndexTerms = new UnmanagedIndexTerms(size);
             _termInfoArray = ArrayPool<TermInfo>.Shared.Rent(size);
+            _unmanagedIndexTerms = new UnmanagedIndexTerms(size);
         }
 
         public void AddRef()
@@ -55,8 +56,6 @@ namespace Lucene.Net.Index
                 int indexSize = 1 + ((int)indexEnum.size - 1) / indexDivisor; // otherwise read index
 
                 var holder = new ArrayHolder(indexSize, directory, name);
-                
-                var before = GC.GetAllocatedBytesForCurrentThread();
 
                 for (int i = 0; indexEnum.Next(state); i++)
                 {
@@ -69,7 +68,7 @@ namespace Lucene.Net.Index
                             break;
                 }
 
-                holder._managedAllocations = GC.GetAllocatedBytesForCurrentThread() - before;
+                holder._managedAllocations = (holder.ActualLongArraySize * (TermInfo.SizeOf + sizeof(long)));
 
                 OnArrayHolderCreated?.Invoke(holder._managedAllocations);
 

--- a/src/Lucene.Net/Index/SegmentTermDocs.cs
+++ b/src/Lucene.Net/Index/SegmentTermDocs.cs
@@ -66,34 +66,34 @@ namespace Lucene.Net.Index
 			TermInfo ti = parent.core.GetTermsReader().Get(term, state);
 			Seek(ti, term, state);
 		}
-		
-		public virtual void  Seek(TermEnum termEnum, IState state)
-		{
-			TermInfo ti;
-			Term term;
-			
-			// use comparison of fieldinfos to verify that termEnum belongs to the same segment as this SegmentTermDocs
-			if (termEnum is SegmentTermEnum && ((SegmentTermEnum) termEnum).fieldInfos == parent.core.fieldInfos)
-			{
-				// optimized case
-				var segmentTermEnum = ((SegmentTermEnum) termEnum);
+
+        public virtual void Seek(TermEnum termEnum, IState state)
+        {
+            TermInfo ti;
+            Term term;
+
+            // use comparison of fieldinfos to verify that termEnum belongs to the same segment as this SegmentTermDocs
+            if (termEnum is SegmentTermEnum && ((SegmentTermEnum)termEnum).fieldInfos == parent.core.fieldInfos)
+            {
+                // optimized case
+                var segmentTermEnum = ((SegmentTermEnum)termEnum);
 
                 // we avoid using segmentTermEnum.Term because it materializes the term text into a string,
                 // which is unnecessary as the next step only requires the Field, and the Field is already interned.
                 term = new Term(segmentTermEnum.Field, txt: null, intern: false);
                 ti = segmentTermEnum.TermInfo();
-			}
-			else
-			{
-				// punt case
-				term = termEnum.Term;
-				ti = parent.core.GetTermsReader().Get(term, state);
-			}
-			
-			Seek(ti, term, state);
-		}
-		
-		internal virtual void  Seek(TermInfo ti, Term term, IState state)
+            }
+            else
+            {
+                // punt case
+                term = termEnum.Term;
+                ti = parent.core.GetTermsReader().Get(term, state);
+            }
+
+            Seek(ti, term, state);
+        }
+
+        internal virtual void  Seek(TermInfo ti, Term term, IState state)
 		{
 			count = 0;
 			FieldInfo fi = parent.core.fieldInfos.FieldInfo(term.Field);

--- a/src/Lucene.Net/Index/SegmentTermDocs.cs
+++ b/src/Lucene.Net/Index/SegmentTermDocs.cs
@@ -77,8 +77,11 @@ namespace Lucene.Net.Index
 			{
 				// optimized case
 				var segmentTermEnum = ((SegmentTermEnum) termEnum);
-				term = segmentTermEnum.Term;
-				ti = segmentTermEnum.TermInfo();
+
+                // we avoid using segmentTermEnum.Term because it materializes the term text into a string,
+                // which is unnecessary as the next step only requires the Field, and the Field is already interned.
+                term = new Term(segmentTermEnum.Field, txt: null, intern: false);
+                ti = segmentTermEnum.TermInfo();
 			}
 			else
 			{

--- a/src/Lucene.Net/Index/SegmentTermEnum.cs
+++ b/src/Lucene.Net/Index/SegmentTermEnum.cs
@@ -17,6 +17,7 @@
 
 using Lucene.Net.Store;
 using Lucene.Net.Util;
+using System;
 using IndexInput = Lucene.Net.Store.IndexInput;
 
 namespace Lucene.Net.Index
@@ -195,6 +196,16 @@ namespace Lucene.Net.Index
 	    {
 	        get { return termBuffer.ToTerm(); }
 	    }
+
+        public string Field
+        {
+            get { return termBuffer.Field; }
+        }
+
+        public Span<char> TextAsSpan
+        {
+            get { return termBuffer.TextAsSpan; }
+        }
 
 	    /// <summary>Returns the previous Term enumerated. Initially null.</summary>
 		public /*internal*/ Term Prev()

--- a/src/Lucene.Net/Index/Term.cs
+++ b/src/Lucene.Net/Index/Term.cs
@@ -21,7 +21,6 @@ using StringHelper = Lucene.Net.Util.StringHelper;
 
 namespace Lucene.Net.Index
 {
-
     /// <summary>A Term represents a word from text.  This is the unit of search.  It is
     /// composed of two elements, the text of the word, as a string, and the name of
     /// the field that the text occured in, an interned string.
@@ -140,7 +139,16 @@ namespace Lucene.Net.Index
             
             return String.CompareOrdinal(field, other.field);
 		}
-		
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareTo(UnmanagedTerm other)
+        {
+            if (ReferenceEquals(field, other.Field))
+                return -other.Text.CompareTo(text);
+
+            return String.CompareOrdinal(field, other.Field);
+        }
+
         ///// <summary>Resets the field and text of a Term. </summary>
         //internal void  Set(System.String fld, System.String txt)
         //{

--- a/src/Lucene.Net/Index/TermInfo.cs
+++ b/src/Lucene.Net/Index/TermInfo.cs
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 
-using System;
-
 namespace Lucene.Net.Index
 {
-	
 	/// <summary>A TermInfo is the record of information stored for a term.</summary>
 	
 	public struct TermInfo
 	{
+		public static int SizeOf = sizeof(int) + sizeof(long) + sizeof(long) + sizeof(int);
+
 		/// <summary>The number of documents which contain the term. </summary>
 		internal int docFreq;
 		

--- a/src/Lucene.Net/Index/TermInfosReader.cs
+++ b/src/Lucene.Net/Index/TermInfosReader.cs
@@ -194,30 +194,32 @@ namespace Lucene.Net.Index
 		}
 
 		/// <summary>Returns the offset of the greatest index entry which is less than or equal to term.</summary>
-		private int GetIndexOffset(Term term)
+		private unsafe int GetIndexOffset(Term term)
 		{
 			int lo = 0; // binary search unmanagedIndexTerms[]
 			int hi = unmanagedIndexTerms.Length - 1;
 
             byte[] arr = null;
-            Span<byte> stringAsBytes = stackalloc byte[0]; // relax the compiler
+            Span<byte> stringAsBytes;
             var stringAsSpan = term.Text.AsSpan();
-            var strSize = (ushort)Encoding.UTF8.GetByteCount(stringAsSpan);
+
+            var strSize = Encoding.UTF8.GetMaxByteCount(term.Text.Length);
             if (strSize <= 256) // allocate on the stack
             {
-                stringAsBytes = stackalloc byte[strSize];
+                Span<byte> stackAlloc = stackalloc byte[strSize];
+                Encoding.UTF8.TryGetBytes(stringAsSpan, stackAlloc, out var bytesWritten);
+                stringAsBytes = stackAlloc.Slice(0, bytesWritten);
             }
             else
             {
                 var pooledSize = BitUtil.NextHighestPowerOfTwo(strSize);
                 arr = ArrayPool<byte>.Shared.Rent(pooledSize);
-                stringAsBytes = new Span<byte>(arr, 0, strSize);
+                Encoding.UTF8.TryGetBytes(stringAsSpan, arr, out var bytesWritten);
+                stringAsBytes = new Span<byte>(arr, 0, bytesWritten);
             }
 
             try
             {
-                Encoding.UTF8.GetBytes(stringAsSpan, stringAsBytes);
-
                 while (hi >= lo)
                 {
                     int mid = Number.URShift((lo + hi), 1);

--- a/src/Lucene.Net/Index/TermInfosReader.cs
+++ b/src/Lucene.Net/Index/TermInfosReader.cs
@@ -193,11 +193,11 @@ namespace Lucene.Net.Index
 			return resources;
 		}
 
-		/// <summary>Returns the offset of the greatest index entry which is less than or equal to term.</summary>
-		private unsafe int GetIndexOffset(Term term)
-		{
-			int lo = 0; // binary search unmanagedIndexTerms[]
-			int hi = unmanagedIndexTerms.Length - 1;
+        /// <summary>Returns the offset of the greatest index entry which is less than or equal to term.</summary>
+        private unsafe int GetIndexOffset(Term term)
+        {
+            int lo = 0; // binary search unmanagedIndexTerms[]
+            int hi = unmanagedIndexTerms.Length - 1;
 
             byte[] arr = null;
             Span<byte> stringAsBytes;
@@ -239,7 +239,7 @@ namespace Lucene.Net.Index
                 if (arr != null)
                     ArrayPool<byte>.Shared.Return(arr);
             }
-		}
+        }
 
         private static int CompareTerms(string field, Span<byte> stringAsBytes, ReadOnlySpan<char> stringAsChar, UnmanagedTerm unmanagedTerm)
         {

--- a/src/Lucene.Net/Index/TermInfosReader.cs
+++ b/src/Lucene.Net/Index/TermInfosReader.cs
@@ -16,10 +16,13 @@
  */
 
 using System;
+using System.Buffers;
+using System.Text;
 using Lucene.Net.Store;
 using Lucene.Net.Support;
 using Lucene.Net.Util;
 using Lucene.Net.Util.Lucene4x;
+using static Lucene.Net.Util.UnmanagedStringArray;
 using Directory = Lucene.Net.Store.Directory;
 
 namespace Lucene.Net.Index
@@ -41,7 +44,7 @@ namespace Lucene.Net.Index
 		private readonly SegmentTermEnum origEnum;
 		private readonly long size;
 		
-		private Span<Term> indexTerms => _termsIndexCache.IndexTerms;
+		private UnmanagedIndexTerms unmanagedIndexTerms => _termsIndexCache.UnmanagedIndexTerms;
 		private Span<TermInfo> indexInfos => _termsIndexCache.InfoArray;
 		private Span<long> indexPointers =>_termsIndexCache.LongArray;
 		
@@ -189,26 +192,60 @@ namespace Lucene.Net.Index
 			}
 			return resources;
 		}
-		
+
 		/// <summary>Returns the offset of the greatest index entry which is less than or equal to term.</summary>
 		private int GetIndexOffset(Term term)
 		{
-			int lo = 0; // binary search indexTerms[]
-			int hi = indexTerms.Length - 1;
-			
-			while (hi >= lo)
-			{
-				int mid = Number.URShift((lo + hi), 1);
-				int delta = term.CompareTo(indexTerms[mid]);
-				if (delta < 0)
-					hi = mid - 1;
-				else if (delta > 0)
-					lo = mid + 1;
-				else
-					return mid;
-			}
-			return hi;
+			int lo = 0; // binary search unmanagedIndexTerms[]
+			int hi = unmanagedIndexTerms.Length - 1;
+
+            byte[] arr = null;
+            Span<byte> stringAsBytes = stackalloc byte[0]; // relax the compiler
+            var stringAsSpan = term.Text.AsSpan();
+            var strSize = (ushort)Encoding.UTF8.GetByteCount(stringAsSpan);
+            if (strSize <= 256) // allocate on the stack
+            {
+                stringAsBytes = stackalloc byte[strSize];
+            }
+            else
+            {
+                var pooledSize = BitUtil.NextHighestPowerOfTwo(strSize);
+                arr = ArrayPool<byte>.Shared.Rent(pooledSize);
+                stringAsBytes = new Span<byte>(arr, 0, strSize);
+            }
+
+            try
+            {
+                Encoding.UTF8.GetBytes(stringAsSpan, stringAsBytes);
+
+                while (hi >= lo)
+                {
+                    int mid = Number.URShift((lo + hi), 1);
+                    int delta = CompareTerms(term.Field, stringAsBytes, stringAsSpan, unmanagedIndexTerms[mid]);
+                    if (delta < 0)
+                        hi = mid - 1;
+                    else if (delta > 0)
+                        lo = mid + 1;
+                    else
+                        return mid;
+                }
+
+                return hi;
+            }
+            finally
+            {
+                if (arr != null)
+                    ArrayPool<byte>.Shared.Return(arr);
+            }
 		}
+
+        private static int CompareTerms(string field, Span<byte> stringAsBytes, ReadOnlySpan<char> stringAsChar, UnmanagedTerm unmanagedTerm)
+        {
+            if (ReferenceEquals(field, unmanagedTerm.Field))
+                return UnmanagedString.CompareOrdinal(stringAsBytes, stringAsChar, unmanagedTerm.Text);
+
+            return String.CompareOrdinal(field, unmanagedTerm.Field);
+        }
 		
 	    internal static Term DeepCopyOf(Term other)
 	    {
@@ -219,7 +256,7 @@ namespace Lucene.Net.Index
 
         private void SeekEnum(SegmentTermEnum enumerator, int indexOffset, IState state)
 		{
-			enumerator.Seek(indexPointers[indexOffset], ((long)indexOffset * totalIndexInterval) - 1, indexTerms[indexOffset], indexInfos[indexOffset], state);
+			enumerator.Seek(indexPointers[indexOffset], ((long)indexOffset * totalIndexInterval) - 1, unmanagedIndexTerms[indexOffset].ToTerm(), indexInfos[indexOffset], state);
 		}
 		
 		/// <summary>Returns the TermInfo for a Term in the set, or null. </summary>
@@ -256,7 +293,7 @@ namespace Lucene.Net.Index
 			if (enumerator.Term != null && ((enumerator.Prev() != null && term.CompareTo(enumerator.Prev()) > 0) || term.CompareTo(enumerator.Term) >= 0))
 			{
 				int enumOffset = (int) (enumerator.position / totalIndexInterval) + 1;
-				if (indexTerms.Length == enumOffset || term.CompareTo(indexTerms[enumOffset]) < 0)
+				if (unmanagedIndexTerms.Length == enumOffset || term.CompareTo(unmanagedIndexTerms[enumOffset]) < 0)
 				{
 					// no need to seek
 					
@@ -303,7 +340,7 @@ namespace Lucene.Net.Index
 						
 		private void  EnsureIndexIsRead()
 		{
-			if (indexTerms == null)
+			if (unmanagedIndexTerms == null)
 			{
 				throw new SystemException("terms index was not loaded when this reader was created");
 			}

--- a/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
+++ b/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
@@ -2,41 +2,42 @@ using System;
 using System.Buffers;
 using Lucene.Net.Util;
 
-namespace Lucene.Net.Index;
-
-public class UnmanagedIndexTerms : IDisposable
+namespace Lucene.Net.Index
 {
-    private readonly int _size;
-    private readonly string[] _fields; // fields are interned
-    private readonly UnmanagedStringArray _text;
-
-    public int Length => _text.Length;
-
-    public UnmanagedIndexTerms(int size)
+    public class UnmanagedIndexTerms : IDisposable
     {
-        _size = size;
-        _fields = size > ArrayHolder.MaxSizeToTakeFromArrayPool ? new string[size] : ArrayPool<string>.Shared.Rent(size);
-        _text = new UnmanagedStringArray(size, startIndex: 0);
-    }
+        private readonly int _size;
+        private readonly string[] _fields; // fields are interned
+        private readonly UnmanagedStringArray _text;
 
-    public void Add(int index, string field, Span<char> textAsSpan)
-    {
-        _fields[index] = field;
-        _text.Add(textAsSpan);
-    }
+        public int Length => _text.Length;
 
-    public UnmanagedTerm this[int position]
-    {
-        get => new UnmanagedTerm(_fields[position], _text[position]);
-    }
+        public UnmanagedIndexTerms(int size)
+        {
+            _size = size;
+            _fields = size > ArrayHolder.ArrayPoolThreshold ? new string[size] : ArrayPool<string>.Shared.Rent(size);
+            _text = new UnmanagedStringArray(size, startIndex: 0);
+        }
 
-    public void Dispose()
-    {
-        _text?.Dispose();
+        public void Add(int index, string field, Span<char> textAsSpan)
+        {
+            _fields[index] = field;
+            _text.Add(textAsSpan);
+        }
 
-        if (_size > ArrayHolder.MaxSizeToTakeFromArrayPool || _fields == null)
-            return;
+        public UnmanagedTerm this[int position]
+        {
+            get => new UnmanagedTerm(_fields[position], _text[position]);
+        }
 
-        ArrayPool<string>.Shared.Return(_fields, clearArray: true);
+        public void Dispose()
+        {
+            _text?.Dispose();
+
+            if (_size > ArrayHolder.ArrayPoolThreshold || _fields == null)
+                return;
+
+            ArrayPool<string>.Shared.Return(_fields, clearArray: true);
+        }
     }
 }

--- a/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
+++ b/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
@@ -6,33 +6,37 @@ namespace Lucene.Net.Index;
 
 public class UnmanagedIndexTerms : IDisposable
 {
-    private readonly string[] fields; // fields are interned
-    private readonly UnmanagedStringArray text;
+    private readonly int _size;
+    private readonly string[] _fields; // fields are interned
+    private readonly UnmanagedStringArray _text;
 
-    public int Length => text.Length;
+    public int Length => _text.Length;
 
     public UnmanagedIndexTerms(int size)
     {
-        fields = ArrayPool<string>.Shared.Rent(size); ;
-        text = new UnmanagedStringArray(size, startIndex: 0);
+        _size = size;
+        _fields = size > ArrayHolder.MaxSizeToTakeFromArrayPool ? new string[size] : ArrayPool<string>.Shared.Rent(size);
+        _text = new UnmanagedStringArray(size, startIndex: 0);
     }
 
     public void Add(int index, string field, Span<char> textAsSpan)
     {
-        fields[index] = field;
-        text.Add(textAsSpan);
+        _fields[index] = field;
+        _text.Add(textAsSpan);
     }
 
     public UnmanagedTerm this[int position]
     {
-        get => new UnmanagedTerm(fields[position], text[position]);
+        get => new UnmanagedTerm(_fields[position], _text[position]);
     }
 
     public void Dispose()
     {
-        text?.Dispose();
+        _text?.Dispose();
 
-        if (fields != null && Length <= 256 * 1024)
-            ArrayPool<string>.Shared.Return(fields, clearArray: true);
+        if (_size > ArrayHolder.MaxSizeToTakeFromArrayPool || _fields == null)
+            return;
+
+        ArrayPool<string>.Shared.Return(_fields, clearArray: true);
     }
 }

--- a/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
+++ b/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
@@ -16,7 +16,7 @@ namespace Lucene.Net.Index
         {
             _size = size;
             _fields = size > ArrayHolder.ArrayPoolThreshold ? new string[size] : ArrayPool<string>.Shared.Rent(size);
-            _text = new UnmanagedStringArray(size, startIndex: 0);
+            _text = new UnmanagedStringArray(size, 0, UnmanagedStringArray.Type.TermCache);
         }
 
         public void Add(int index, string field, Span<char> textAsSpan)

--- a/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
+++ b/src/Lucene.Net/Index/UnmanagedIndexTerms.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Buffers;
+using Lucene.Net.Util;
+
+namespace Lucene.Net.Index;
+
+public class UnmanagedIndexTerms : IDisposable
+{
+    private readonly string[] fields; // fields are interned
+    private readonly UnmanagedStringArray text;
+
+    public int Length => text.Length;
+
+    public UnmanagedIndexTerms(int size)
+    {
+        fields = ArrayPool<string>.Shared.Rent(size); ;
+        text = new UnmanagedStringArray(size, startIndex: 0);
+    }
+
+    public void Add(int index, string field, Span<char> textAsSpan)
+    {
+        fields[index] = field;
+        text.Add(textAsSpan);
+    }
+
+    public UnmanagedTerm this[int position]
+    {
+        get => new UnmanagedTerm(fields[position], text[position]);
+    }
+
+    public void Dispose()
+    {
+        text?.Dispose();
+
+        if (fields != null && Length <= 256 * 1024)
+            ArrayPool<string>.Shared.Return(fields, clearArray: true);
+    }
+}

--- a/src/Lucene.Net/Index/UnmanagedTerm.cs
+++ b/src/Lucene.Net/Index/UnmanagedTerm.cs
@@ -1,0 +1,24 @@
+using Lucene.Net.Util;
+
+namespace Lucene.Net.Index;
+
+public class UnmanagedTerm
+{
+    private readonly string field;
+    private readonly UnmanagedStringArray.UnmanagedString unmanagedString;
+
+    public string Field => field;
+
+    public UnmanagedStringArray.UnmanagedString Text => unmanagedString;
+
+    public UnmanagedTerm(string field, UnmanagedStringArray.UnmanagedString unmanagedString)
+    {
+        this.field = field;
+        this.unmanagedString = unmanagedString;
+    }
+
+    public Term ToTerm()
+    {
+        return new Term(field, unmanagedString.ToString(), false);
+    }
+}

--- a/src/Lucene.Net/Index/UnmanagedTerm.cs
+++ b/src/Lucene.Net/Index/UnmanagedTerm.cs
@@ -1,24 +1,25 @@
 using Lucene.Net.Util;
 
-namespace Lucene.Net.Index;
-
-public class UnmanagedTerm
+namespace Lucene.Net.Index
 {
-    private readonly string field;
-    private readonly UnmanagedStringArray.UnmanagedString unmanagedString;
-
-    public string Field => field;
-
-    public UnmanagedStringArray.UnmanagedString Text => unmanagedString;
-
-    public UnmanagedTerm(string field, UnmanagedStringArray.UnmanagedString unmanagedString)
+    public class UnmanagedTerm
     {
-        this.field = field;
-        this.unmanagedString = unmanagedString;
-    }
+        private readonly string field;
+        private readonly UnmanagedStringArray.UnmanagedString unmanagedString;
 
-    public Term ToTerm()
-    {
-        return new Term(field, unmanagedString.ToString(), false);
+        public string Field => field;
+
+        public UnmanagedStringArray.UnmanagedString Text => unmanagedString;
+
+        public UnmanagedTerm(string field, UnmanagedStringArray.UnmanagedString unmanagedString)
+        {
+            this.field = field;
+            this.unmanagedString = unmanagedString;
+        }
+
+        public Term ToTerm()
+        {
+            return new Term(field, unmanagedString.ToString(), false);
+        }
     }
 }

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -92,13 +92,10 @@ namespace Lucene.Net.Search
         /// <summary>For each document, an index into the lookup array. </summary>
         public int[] order;
 
-        public int[] reverseOrder;
-
         /// <summary>Creates one of these objects </summary>
-        public StringIndex(int[] values, int[] reverseOrder, UnmanagedStringArray lookup)
+        public StringIndex(int[] values, UnmanagedStringArray lookup)
         {
             this.order = values;
-            this.reverseOrder = reverseOrder;
             this.lookup = lookup;
         }
     }

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -785,11 +785,6 @@ namespace Lucene.Net.Search
             {
                 System.String field = StringHelper.Intern(entryKey.field);
                 int[] retArray = new int[reader.MaxDoc];
-                int[] retArrayOrdered = new int[reader.MaxDoc];
-                for (int i = 0; i < retArrayOrdered.Length; i++)
-                {
-                    retArrayOrdered[i] = -1;
-                }
 
                 var length = reader.MaxDoc + 1;
                 UnmanagedStringArray mterms = new UnmanagedStringArray(length, startIndex: 1);
@@ -797,7 +792,7 @@ namespace Lucene.Net.Search
                 
                 SegmentTermEnum termEnum = (SegmentTermEnum)reader.Terms(new Term(field), state);
                 int termNumber = 0; // current term number
-                int docIndex = 0;
+
                 // an entry for documents that have no terms in this field
                 // should a document with no terms be at top or bottom?
                 // this puts them at the top - if it is changed, FieldDocSortedHitQueue
@@ -816,11 +811,7 @@ namespace Lucene.Net.Search
                         while (termDocs.Next(state))
                         {
                             canAdd = true;
-                            var pt = retArray[termDocs.Doc];
                             retArray[termDocs.Doc] = termNumber;
-
-                            if (pt == 0)
-                                retArrayOrdered[docIndex++] = termDocs.Doc;
                         }
 
                         if (canAdd)
@@ -844,7 +835,7 @@ namespace Lucene.Net.Search
                     termEnum.Close();
                 }
 
-                StringIndex value_Renamed = new StringIndex(retArray, retArrayOrdered, mterms);
+                StringIndex value_Renamed = new StringIndex(retArray, mterms);
                 return value_Renamed;
             }
 

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -787,7 +787,7 @@ namespace Lucene.Net.Search
                 int[] retArray = new int[reader.MaxDoc];
 
                 var length = reader.MaxDoc + 1;
-                UnmanagedStringArray mterms = new UnmanagedStringArray(length, startIndex: 1);
+                UnmanagedStringArray mterms = new UnmanagedStringArray(length, 1, UnmanagedStringArray.Type.Sorting);
                 TermDocs termDocs = reader.TermDocs(state);
                 
                 SegmentTermEnum termEnum = (SegmentTermEnum)reader.Terms(new Term(field), state);

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -9,7 +9,7 @@ namespace Lucene.Net.Util
 {
     public unsafe class UnmanagedStringArray : IDisposable
     {
-        public class Segment : IDisposable
+        public class Segment: IDisposable
         {
             public readonly int Size;
 
@@ -149,6 +149,11 @@ namespace Lucene.Net.Util
                 //   while non-ASCII starts with bytes >=192, so non-ASCII is always greater)
                 // therefore, comparing the byte sequences directly produces the correct result.
                 return strA.StringAsBytes.SequenceCompareTo(strBAsBytes);
+            }
+
+            public static int CompareOrdinal(Span<byte> strA, ReadOnlySpan<char> aAsChars, UnmanagedString strB)
+            {
+                return -CompareOrdinal(strB, strA, aAsChars);
             }
 
             public int CompareTo(object other)

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -9,26 +9,34 @@ namespace Lucene.Net.Util
 {
     public unsafe class UnmanagedStringArray : IDisposable
     {
+        public enum Type
+        {
+            TermCache,
+            Sorting
+        }
+
         public class Segment: IDisposable
         {
             public readonly int Size;
+            private readonly Type _type;
 
             public byte* Start;
             public byte* CurrentPosition => Start + Used;
             public int Free => Size - Used;
             public int Used;
 
-            public delegate byte* AllocateSegmentDelegate(long size);
-            public delegate void FreeSegmentDelegate(byte* ptr, long size);
+            public delegate byte* AllocateSegmentDelegate(long size, Type type);
+            public delegate void FreeSegmentDelegate(byte* ptr, long size, Type type);
 
-            public static AllocateSegmentDelegate AllocateMemory = (size) => (byte*) Marshal.AllocHGlobal((IntPtr) size);
-            public static FreeSegmentDelegate FreeMemory = (ptr, _) => Marshal.FreeHGlobal((IntPtr) ptr);
+            public static AllocateSegmentDelegate AllocateMemory = (size, _) => (byte*) Marshal.AllocHGlobal((IntPtr) size);
+            public static FreeSegmentDelegate FreeMemory = (ptr, _, __) => Marshal.FreeHGlobal((IntPtr) ptr);
 
-            public Segment(int size)
+            public Segment(int size, Type type)
             {
-                Start = AllocateMemory(size);
+                Start = AllocateMemory(size, type);
                 Used = 0;
                 Size = size;
+                _type = type;
             }
 
             public byte* Add(int size)
@@ -66,7 +74,7 @@ namespace Lucene.Net.Util
                 GC.SuppressFinalize(this);
                 if (Start != null)
                 {
-                    FreeMemory(Start, Size);
+                    FreeMemory(Start, Size, _type);
                 }
                 Start = null;
             }
@@ -205,11 +213,13 @@ namespace Lucene.Net.Util
 
         public int Length => _index;
         public int _index;
+        private readonly Type _type;
 
-        public UnmanagedStringArray(int size, int startIndex)
+        public UnmanagedStringArray(int size, int startIndex, Type type)
         {
             _strings = new UnmanagedString[size];
             _index = startIndex;
+            _type = type;
         }
 
         private Segment GetSegment(int size)
@@ -246,7 +256,7 @@ namespace Lucene.Net.Util
 
         private Segment GetAndAddNewSegment(int segmentSize)
         {
-            var newSegment = new Segment(segmentSize);
+            var newSegment = new Segment(segmentSize, _type);
             _segments.Add(newSegment);
             return newSegment;
         }

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -13,7 +13,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_All_Terms()
         {
-            using (var terms = new UnmanagedStringArray(11, startIndex: 1))
+            using (var terms = new UnmanagedStringArray(11, startIndex: 1, UnmanagedStringArray.Type.Sorting))
             {
                 for (var letter = 'a'; letter <= 'j'; letter++)
                 {
@@ -33,7 +33,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_With_Missing_Terms()
         {
-            var terms = new UnmanagedStringArray(11, startIndex: 1);
+            var terms = new UnmanagedStringArray(11, startIndex: 1, UnmanagedStringArray.Type.Sorting);
             var count = 0;
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -62,7 +62,7 @@ namespace Lucene.Net.Search
 
             VerifyNonExistingTerms(terms);
 
-            terms = new UnmanagedStringArray(11, startIndex: 1);
+            terms = new UnmanagedStringArray(11, startIndex: 1, UnmanagedStringArray.Type.Sorting);
 
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -89,7 +89,7 @@ namespace Lucene.Net.Search
 
             VerifyNonExistingTerms(terms);
 
-            terms = new UnmanagedStringArray(11, startIndex: 1);
+            terms = new UnmanagedStringArray(11, startIndex: 1, UnmanagedStringArray.Type.Sorting);
 
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -126,7 +126,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_Terms()
         {
-            using (var terms = new UnmanagedStringArray(char.MaxValue + 1, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(char.MaxValue + 1, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 for (int code = char.MinValue; code <= char.MaxValue; code++)
                 {
@@ -167,7 +167,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 foreach (var str in sortedStrings)
                 {
@@ -209,7 +209,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 foreach (var str in sortedStrings)
                 {
@@ -280,7 +280,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 foreach (var str in sortedStrings)
                 {
@@ -300,7 +300,7 @@ namespace Lucene.Net.Search
         [Test]
         public unsafe void Compare_Unmanaged_Strings()
         {
-            using (var terms = new UnmanagedStringArray(128, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(128, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 const string word1 = "";
                 terms.Add(word1.ToCharArray());
@@ -482,7 +482,7 @@ namespace Lucene.Net.Search
 
         private static void VerifyNonExistingTerms(UnmanagedStringArray terms)
         {
-            using (var internalTerms = new UnmanagedStringArray(3, startIndex: 0))
+            using (var internalTerms = new UnmanagedStringArray(3, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 const string smallerThan = "A";
                 const string biggerThan = "z";

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -307,9 +307,13 @@ namespace Lucene.Net.Search
 
                 var result = UnmanagedString.CompareOrdinal(terms[0], Span<byte>.Empty, Span<char>.Empty);
                 Assert.AreEqual(0, result);
+                result = UnmanagedString.CompareOrdinal(Span<byte>.Empty, Span<char>.Empty, terms[0]);
+                Assert.AreEqual(0, result);
 
                 result = UnmanagedString.CompareOrdinal(new UnmanagedString(), Span<byte>.Empty, Span<char>.Empty);
                 Assert.AreEqual(-1, result);
+                result = UnmanagedString.CompareOrdinal(Span<byte>.Empty, Span<char>.Empty, new UnmanagedString());
+                Assert.AreEqual(1, result);
 
                 const string word2 = "גרישה";
                 terms.Add(word2.ToCharArray());
@@ -317,12 +321,18 @@ namespace Lucene.Net.Search
                 // we pass Span<byte>.Empty since we compare by chars and not by bytes
                 result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "גרישה");
                 Assert.AreEqual(0, result);
+                result = UnmanagedString.CompareOrdinal(Span<byte>.Empty, "גרישה", terms[1]);
+                Assert.AreEqual(0, result);
 
                 result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "כרמל");
                 Assert.True(result < 0);
+                result = UnmanagedString.CompareOrdinal(Span<byte>.Empty, "כרמל", terms[1]);
+                Assert.True(result > 0);
 
                 result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "אורן");
                 Assert.True(result > 0);
+                result = UnmanagedString.CompareOrdinal(Span<byte>.Empty, "אורן", terms[1]);
+                Assert.True(result < 0);
 
                 const string word3 = "zebra";
                 terms.Add(word3.ToCharArray());
@@ -334,6 +344,8 @@ namespace Lucene.Net.Search
                 Encoding.UTF8.GetBytes(toCompare1, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
                 Assert.True(result < 0);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
+                Assert.True(result > 0);
 
                 var toCompare2 = "כרמל";
                 size = Encoding.UTF8.GetByteCount(toCompare2);
@@ -341,6 +353,8 @@ namespace Lucene.Net.Search
                 Encoding.UTF8.GetBytes(toCompare2, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
                 Assert.True(result < 0);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
+                Assert.True(result > 0);
 
                 var toCompare3 = "אורן";
                 size = Encoding.UTF8.GetByteCount(toCompare3);
@@ -348,23 +362,31 @@ namespace Lucene.Net.Search
                 Encoding.UTF8.GetBytes(toCompare3, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
                 Assert.True(result < 0);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
+                Assert.True(result > 0);
 
                 size = Encoding.UTF8.GetByteCount(word1);
                 stringAsBytes = stackalloc byte[size];
                 Encoding.UTF8.GetBytes(word1, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
                 Assert.True(result > 0);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
+                Assert.True(result < 0);
 
                 size = Encoding.UTF8.GetByteCount(word2);
                 stringAsBytes = stackalloc byte[size];
                 Encoding.UTF8.GetBytes(word2, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
                 Assert.True(result < 0);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
+                Assert.True(result > 0);
 
                 size = Encoding.UTF8.GetByteCount(word3);
                 stringAsBytes = stackalloc byte[size];
                 Encoding.UTF8.GetBytes(word3, stringAsBytes);
                 result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.AreEqual(0, result);
+                result = UnmanagedString.CompareOrdinal(stringAsBytes, Span<char>.Empty, terms[2]);
                 Assert.AreEqual(0, result);
 
                 result = terms[0].CompareTo(toCompare1);
@@ -411,7 +433,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Compare_Various_Length_Unmanaged_Strings()
         {
-            using (var terms = new UnmanagedStringArray(64 * 4, startIndex: 0))
+            using (var terms = new UnmanagedStringArray(64 * 4, startIndex: 0, UnmanagedStringArray.Type.TermCache))
             {
                 var strings = new List<string>();
                 for (var i = 0; i < 64; i++)


### PR DESCRIPTION
- Use unmanaged string array instead of strings to reduce GC pressure.
- Use ArrayPool for string arrays when size is within limits, otherwise allocate directly