### PR TITLE
RavenDB-23414 - Fix order by unicode when using UnmanagedStringArray

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 3.1.201
+        dotnet-version: 8.0.404
 
     - name: Install dependencies
       run: dotnet restore

--- a/src/Lucene.Net/Lucene.Net.csproj
+++ b/src/Lucene.Net/Lucene.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net</AssemblyTitle>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Lucene.Net</AssemblyName>
     <PackageId>Lucene.Net</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Lucene.Net/Messages/NLS.cs
+++ b/src/Lucene.Net/Messages/NLS.cs
@@ -251,11 +251,11 @@ namespace Lucene.Net.Messages
 		private static void  MakeAccessible(System.Reflection.FieldInfo field)
 		{
 #if !NETSTANDARD2_1
-            if (System.Security.SecurityManager.SecurityEnabled)
+            //if (System.Security.SecurityManager.SecurityEnabled)
 			{
 				//field.setAccessible(true);   // {{Aroush-2.9}} java.lang.reflect.AccessibleObject.setAccessible
 			}
-			else
+            //else
 			{
                 //AccessController.doPrivileged(new AnonymousClassPrivilegedAction(field));     // {{Aroush-2.9}} java.security.AccessController.doPrivileged
 			}

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -35,7 +35,7 @@ namespace Lucene.Net.Search
     /// <summary>Expert: Stores term text values and document ordering data. </summary>
     public class StringIndex
     {
-        public virtual int BinarySearchLookup(System.String key)
+        public virtual unsafe int BinarySearchLookup(System.String key)
         {
             // this special case is the reason that Arrays.binarySearch() isn't useful.
             if (key == null)
@@ -45,26 +45,26 @@ namespace Lucene.Net.Search
             int high = lookup.Length - 1;
 
             byte[] arr = null;
-            Span<byte> stringAsBytes = stackalloc byte[0]; // relax the compiler
+            Span<byte> stringAsBytes;
             var stringAsSpan = key.AsSpan();
 
-            var size = (ushort) Encoding.UTF8.GetByteCount(stringAsSpan);
-
+            var size = Encoding.UTF8.GetMaxByteCount(key.Length);
             if (size <= 256) // allocate on the stack
             {
-                stringAsBytes = stackalloc byte[size];
+                Span<byte> stackAlloc = stackalloc byte[size];
+                Encoding.UTF8.TryGetBytes(stringAsSpan, stackAlloc, out var bytesWritten);
+                stringAsBytes = stackAlloc.Slice(0, bytesWritten);
             }
             else
             {
                 var pooledSize = BitUtil.NextHighestPowerOfTwo(size);
                 arr = ArrayPool<byte>.Shared.Rent(pooledSize);
-                stringAsBytes = new Span<byte>(arr, 0, size);
+                Encoding.UTF8.TryGetBytes(stringAsSpan, arr, out var bytesWritten);
+                stringAsBytes = new Span<byte>(arr, 0, bytesWritten);
             }
 
             try
             {
-                Encoding.UTF8.GetBytes(stringAsSpan, stringAsBytes);
-
                 while (low <= high)
                 {
                     int mid = Number.URShift((low + high), 1);

--- a/src/Lucene.Net/Search/FieldCache.cs
+++ b/src/Lucene.Net/Search/FieldCache.cs
@@ -68,7 +68,7 @@ namespace Lucene.Net.Search
                 while (low <= high)
                 {
                     int mid = Number.URShift((low + high), 1);
-                    int cmp = UnmanagedStringArray.UnmanagedString.CompareOrdinal(lookup[mid], stringAsBytes);
+                    int cmp = UnmanagedStringArray.UnmanagedString.CompareOrdinal(lookup[mid], stringAsBytes, stringAsSpan);
 
                     if (cmp < 0)
                         low = mid + 1;

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -792,7 +792,7 @@ namespace Lucene.Net.Search
                 }
 
                 var length = reader.MaxDoc + 1;
-                UnmanagedStringArray mterms = new UnmanagedStringArray(length);
+                UnmanagedStringArray mterms = new UnmanagedStringArray(length, startIndex: 1);
                 TermDocs termDocs = reader.TermDocs(state);
                 
                 SegmentTermEnum termEnum = (SegmentTermEnum)reader.Terms(new Term(field), state);

--- a/src/Lucene.Net/Util/ConfigurationManager.cs
+++ b/src/Lucene.Net/Util/ConfigurationManager.cs
@@ -1,13 +1,9 @@
-﻿#if NETSTANDARD2_1
-using Microsoft.Extensions.Configuration;
-
-#endif
+﻿using Microsoft.Extensions.Configuration;
 
 namespace Lucene.Net.Util
 {
     internal static class ConfigurationManager
     {
-#if NETSTANDARD2_1
         private static readonly IConfigurationRoot configuration;
 
         static ConfigurationManager()
@@ -15,15 +11,10 @@ namespace Lucene.Net.Util
             var builder = new ConfigurationBuilder().AddJsonFile("appsettings.json", optional: true);
             configuration = builder.Build();
         }
-#endif
 
         public static string GetAppSetting(string key)
         {
-#if NETSTANDARD2_1
             return configuration[key];
-#else
-            return System.Configuration.ConfigurationManager.AppSettings[key];
-#endif
         }
     }
 }

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -31,19 +31,34 @@ namespace Lucene.Net.Util
                 Size = size;
             }
 
-            public void Add(ushort size, out byte* position)
+            public byte* Add(int size)
             {
-                position = CurrentPosition;
-                *(ushort*) CurrentPosition = size;
+                var position = CurrentPosition;
+                *(int*)CurrentPosition = size;
 
-                Used += sizeof(short) + size;
+                Used += sizeof(int) + size;
                 if (Used > Size)
                     ThrowOutOfRange(size);
+
+                return position;
             }
 
-            private void ThrowOutOfRange(ushort size)
+            public void Return(int amountToReturn)
             {
-                throw new ArgumentOutOfRangeException(nameof(Used),$"Requested:{size}, Used: {Used}, but my max size is {Size}");
+                Used -= amountToReturn;
+
+                if (Used < 0)
+                    ThrowUnderflow();
+            }
+
+            private void ThrowOutOfRange(int size)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Used), $"Add operation failed: Requested size {size}, Used: {Used}, Max Size: {Size}");
+            }
+
+            private void ThrowUnderflow()
+            {
+                throw new InvalidOperationException($"Return operation failed: Memory usage underflow. Current Used: {Used}");
             }
 
             public void Dispose()
@@ -66,13 +81,15 @@ namespace Lucene.Net.Util
         {
             public byte* Start;
 
-            public int Size => IsNull ? 0 : *(ushort*) Start;
-            public Span<byte> StringAsBytes => new Span<byte>(Start + sizeof(ushort), Size);
+            public int Size => IsNull ? 0 : (*(int*)Start >> 1);
+            public bool StoredAsAscii => (*(int*)Start & 1) == 1;
+            public Span<byte> StringAsBytes => new Span<byte>(Start + sizeof(int), Size);
+            public Span<char> StringAsChars => new Span<char>(Start + sizeof(int), Size);
             public bool IsNull => Start == default;
             
             public override string ToString()
             {
-                return Encoding.UTF8.GetString(StringAsBytes);
+                return StoredAsAscii ? Encoding.UTF8.GetString(StringAsBytes) : new string(StringAsChars);
             }
 
             public static int CompareOrdinal(UnmanagedString strA, UnmanagedString strB)
@@ -86,32 +103,58 @@ namespace Lucene.Net.Util
                 if (strA.IsNull)
                     return -1;
 
-                return strA.StringAsBytes.SequenceCompareTo(strB.StringAsBytes);
+                return strA.StoredAsAscii switch
+                {
+                    true when strB.StoredAsAscii => strA.StringAsBytes.SequenceCompareTo(strB.StringAsBytes),
+                    false when strB.StoredAsAscii == false => strA.StringAsChars.SequenceCompareTo(strB.StringAsChars),
+                    false when strB.StoredAsAscii => CompareChars(strA.StringAsChars, strB.StringAsBytes),
+                    true when strB.StoredAsAscii == false => -CompareChars(strB.StringAsChars, strA.StringAsBytes),
+                    _ => ThrowNotHandledCase(strA, strB)
+                };
             }
 
-            public static int CompareOrdinal(UnmanagedString strA, Span<byte> strB)
+            private static int CompareChars(Span<char> stringAsChars, Span<byte> asciiAsBytes)
             {
-                if (strA.IsNull && strB == null)
-                    return 0;
+                var minLength = Math.Min(stringAsChars.Length, asciiAsBytes.Length);
 
-                if (strB == null)
-                    return 1;
+                for (var i = 0; i < minLength; i++)
+                {
+                    var utfChar = stringAsChars[i];
+                    var asciiChar = (char)asciiAsBytes[i];
 
+                    if (utfChar != asciiChar)
+                        return utfChar - asciiChar;
+                }
+
+                return stringAsChars.Length - asciiAsBytes.Length;
+            }
+
+            private static int ThrowNotHandledCase(UnmanagedString strA, UnmanagedString strB)
+            {
+                // shouldn't happen
+                throw new ArgumentOutOfRangeException($"strA stored as ascii {strA.StoredAsAscii}, strB stored as ascii {strB.StoredAsAscii}");
+            }
+
+            public static int CompareOrdinal(UnmanagedString strA, Span<byte> strBAsBytes, ReadOnlySpan<char> strBAsChars)
+            {
                 if (strA.IsNull)
                     return -1;
 
-                return strA.StringAsBytes.SequenceCompareTo(strB);
-            }
+                if (strA.StoredAsAscii == false)
+                    return strA.StringAsChars.SequenceCompareTo(strBAsChars);
 
-            public static int CompareOrdinal(Span<byte> strA, UnmanagedString strB)
-            {
-                return -CompareOrdinal(strB, strA);
+                // the following comparison works correctly for UTF-8 encoded strings when:
+                // - comparing ASCII characters (0-127) with each other (single byte comparison)
+                // - comparing ASCII with non-ASCII (ASCII uses single byte starting with '0',
+                //   while non-ASCII starts with bytes >=192, so non-ASCII is always greater)
+                // therefore, comparing the byte sequences directly produces the correct result.
+                return strA.StringAsBytes.SequenceCompareTo(strBAsBytes);
             }
 
             public int CompareTo(object other)
             {
                 if (other == null)
-                    return CompareOrdinal(this, null);
+                    return IsNull ? 0 : 1;
 
                 if (other is UnmanagedString us)
                     return CompareOrdinal(this, us);
@@ -122,7 +165,7 @@ namespace Lucene.Net.Util
                     Span<byte> stringAsBytes = stackalloc byte[0]; // relax the compiler
                     var stringAsSpan = s.AsSpan();
 
-                    var size = (ushort) Encoding.UTF8.GetByteCount(stringAsSpan);
+                    var size = (ushort)Encoding.UTF8.GetByteCount(stringAsSpan);
 
                     if (size <= 256) // allocate on the stack
                     {
@@ -138,7 +181,7 @@ namespace Lucene.Net.Util
                     try
                     {
                         Encoding.UTF8.GetBytes(stringAsSpan, stringAsBytes);
-                        return CompareOrdinal(this, stringAsBytes);
+                        return CompareOrdinal(this, stringAsBytes, stringAsSpan);
                     }
                     finally
                     {
@@ -155,11 +198,12 @@ namespace Lucene.Net.Util
         private List<Segment> _segments = new List<Segment>();
 
         public int Length => _index;
-        public int _index = 1;
+        public int _index;
 
-        public UnmanagedStringArray(int size)
+        public UnmanagedStringArray(int size, int startIndex)
         {
             _strings = new UnmanagedString[size];
+            _index = startIndex;
         }
 
         private Segment GetSegment(int size)
@@ -203,14 +247,37 @@ namespace Lucene.Net.Util
 
         public void Add(Span<char> str)
         {
-            var size = (ushort) Encoding.UTF8.GetByteCount(str);
-            var segment = GetSegment(size + sizeof(ushort));
+            // attempt to encode as ascii bytes
+            var sizeForBytes = str.Length + sizeof(int);  // assume 1 byte per char for ascii
+            var segment = GetSegment(sizeForBytes);
+            var pos = segment.Add(str.Length);
+            var outputByteBuffer = new Span<byte>(pos + sizeof(int), str.Length);
+            if (Encoding.UTF8.TryGetBytes(str, outputByteBuffer, out var bytesWritten))
+            {
+                // all characters are ascii, store as bytes
+                *((int*)pos) = bytesWritten << 1 | 1;  // 1 flag for ascii
+            }
+            else
+            {
+                // the destination was too small to contain all the encoded bytes
+                // which means that it contains non-ascii, revert and process as chars
+                segment.Return(sizeForBytes);
 
-            segment.Add(size, out var position);
+                var sizeForChars = str.Length * sizeof(char) + sizeof(int);
+                if (segment.Free < sizeForChars)
+                {
+                    segment = GetSegment(sizeForChars);
+                }
 
-            Encoding.UTF8.GetBytes(str, new Span<byte>(position + sizeof(ushort), size));
+                pos = segment.Add(str.Length * sizeof(char));
 
-            _strings[_index].Start = position;
+                var outputBuffer = new Span<char>(pos + sizeof(int), str.Length);
+                str.CopyTo(outputBuffer);
+
+                *((int*)pos) = str.Length << 1 | 0; // 0 flag for chars
+            }
+
+            _strings[_index].Start = pos;
             _index++;
         }
 

--- a/src/Lucene.Net/Util/UnmanagedStringArray.cs
+++ b/src/Lucene.Net/Util/UnmanagedStringArray.cs
@@ -162,25 +162,26 @@ namespace Lucene.Net.Util
                 if (other is string s)
                 {
                     byte[] arr = null;
-                    Span<byte> stringAsBytes = stackalloc byte[0]; // relax the compiler
+                    Span<byte> stringAsBytes;
                     var stringAsSpan = s.AsSpan();
 
-                    var size = (ushort)Encoding.UTF8.GetByteCount(stringAsSpan);
-
+                    var size = Encoding.UTF8.GetMaxByteCount(s.Length);
                     if (size <= 256) // allocate on the stack
                     {
-                        stringAsBytes = stackalloc byte[size];
+                        Span<byte> stackAlloc = stackalloc byte[size];
+                        Encoding.UTF8.TryGetBytes(stringAsSpan, stackAlloc, out var bytesWritten);
+                        stringAsBytes = stackAlloc.Slice(0, bytesWritten);
                     }
                     else
                     {
                         var pooledSize = BitUtil.NextHighestPowerOfTwo(size);
                         arr = ArrayPool<byte>.Shared.Rent(pooledSize);
-                        stringAsBytes = new Span<byte>(arr, 0, size);
+                        Encoding.UTF8.TryGetBytes(stringAsSpan, arr, out var bytesWritten);
+                        stringAsBytes = new Span<byte>(arr, 0, bytesWritten);
                     }
 
                     try
                     {
-                        Encoding.UTF8.GetBytes(stringAsSpan, stringAsBytes);
                         return CompareOrdinal(this, stringAsBytes, stringAsSpan);
                     }
                     finally

--- a/src/contrib/Lucene.Net.Contrib.FastVectorHighlighter/Lucene.Net.Contrib.FastVectorHighlighter.csproj
+++ b/src/contrib/Lucene.Net.Contrib.FastVectorHighlighter/Lucene.Net.Contrib.FastVectorHighlighter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net Contrib FastVectorHighlighter</AssemblyTitle>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Lucene.Net.Contrib.FastVectorHighlighter</AssemblyName>
     <DefineConstants>$(DefineConstants);LUCENENET_350</DefineConstants>
     <PackageId>Lucene.Net.Contrib.FastVectorHighlighter</PackageId>

--- a/src/contrib/Lucene.Net.Contrib.Spatial.NTS/Lucene.Net.Contrib.Spatial.NTS.csproj
+++ b/src/contrib/Lucene.Net.Contrib.Spatial.NTS/Lucene.Net.Contrib.Spatial.NTS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Lucene.Net Contrib Spatial NTS</AssemblyTitle>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Lucene.Net.Contrib.Spatial.NTS</AssemblyName>
     <PackageId>Lucene.Net.Contrib.Spatial.NTS</PackageId>
   </PropertyGroup>

--- a/src/demo/Demo.Common/Demo.Common.csproj
+++ b/src/demo/Demo.Common/Demo.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Demo Common</AssemblyTitle>
     <VersionPrefix>3.0.12</VersionPrefix>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Demo.Common</AssemblyName>
     <AssemblyOriginatorKeyFile>Lucene.Net.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/Lucene.Net.Test/Index/TestIndexWriter.cs
+++ b/test/Lucene.Net.Test/Index/TestIndexWriter.cs
@@ -2959,7 +2959,7 @@ namespace Lucene.Net.Index
                     for (int i = 0; i < frames.Length; i++)
                     {
                         System.Diagnostics.StackFrame sf = frames[i];
-                        if ("Abort".Equals(sf.GetMethod().Name) || "FlushDocument".Equals(sf.GetMethod().Name))
+                        if ("Abort".Equals(sf.GetMethod().Name) || "FlushDocument".Equals(sf.GetMethod().Name) || "FinishDocument".Equals(sf.GetMethod().Name))
                         {
                             if (onlyOnce)
                                 doFail = false;

--- a/test/Lucene.Net.Test/Lucene.Net.Test.csproj
+++ b/test/Lucene.Net.Test/Lucene.Net.Test.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeFrameworkVersion>3.1.3</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Lucene.Net.Test</AssemblyName>
     <PackageId>Lucene.Net.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DefineConstants>$(DefineConstants);SHARP_ZIP_LIB</DefineConstants>
+	<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 using Lucene.Net.Index;
 using Lucene.Net.Util;
@@ -13,7 +14,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_All_Terms()
         {
-            var terms = new UnmanagedStringArray(11);
+            var terms = new UnmanagedStringArray(11, startIndex: 1);
 
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -32,7 +33,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_With_Missing_Terms()
         {
-            var terms = new UnmanagedStringArray(11);
+            var terms = new UnmanagedStringArray(11, startIndex: 1);
 
             var count = 0;
             for (var letter = 'a'; letter <= 'j'; letter++)
@@ -62,7 +63,7 @@ namespace Lucene.Net.Search
 
             VerifyNonExistingTerms(terms);
 
-            terms = new UnmanagedStringArray(11);
+            terms = new UnmanagedStringArray(11, startIndex: 1);
 
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -89,7 +90,7 @@ namespace Lucene.Net.Search
 
             VerifyNonExistingTerms(terms);
 
-            terms = new UnmanagedStringArray(11);
+            terms = new UnmanagedStringArray(11, startIndex: 1);
 
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -126,7 +127,7 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_Terms()
         {
-            var terms = new UnmanagedStringArray(char.MaxValue + 1);
+            var terms = new UnmanagedStringArray(char.MaxValue + 1, startIndex: 0);
             for (int code = char.MinValue; code <= char.MaxValue; code++)
             {
                 char letter = (char)code;
@@ -165,7 +166,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
             foreach (var str in sortedStrings)
             {
                 terms.Add(new Span<char>(str.ToCharArray()));
@@ -205,7 +206,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
             foreach (var str in sortedStrings)
             {
                 terms.Add(new Span<char>(str.ToCharArray()));
@@ -274,7 +275,7 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
             foreach (var str in sortedStrings)
             {
                 terms.Add(new Span<char>(str.ToCharArray()));
@@ -289,6 +290,117 @@ namespace Lucene.Net.Search
             }
         }
 
+        [Test]
+        public unsafe void Compare_Unmanaged_Strings()
+        {
+            using (var terms = new UnmanagedStringArray(128, startIndex: 0))
+            {
+                const string word1 = "";
+                terms.Add(word1.ToCharArray());
+
+                var result = UnmanagedString.CompareOrdinal(terms[0], Span<byte>.Empty, Span<char>.Empty);
+                Assert.AreEqual(0, result);
+
+                result = UnmanagedString.CompareOrdinal(new UnmanagedString(), Span<byte>.Empty, Span<char>.Empty);
+                Assert.AreEqual(-1, result);
+
+                const string word2 = "גרישה";
+                terms.Add(word2.ToCharArray());
+
+                // we pass Span<byte>.Empty since we compare by chars and not by bytes
+                result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "גרישה");
+                Assert.AreEqual(0, result);
+
+                result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "כרמל");
+                Assert.True(result < 0);
+
+                result = UnmanagedString.CompareOrdinal(terms[1], Span<byte>.Empty, "אורן");
+                Assert.True(result > 0);
+
+                const string word3 = "zebra";
+                terms.Add(word3.ToCharArray());
+
+                // we pass Span<char>.Empty since we compare by bytes and not by chars
+                var toCompare1 = "גרישה";
+                var size = Encoding.UTF8.GetByteCount(toCompare1);
+                Span<byte> stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(toCompare1, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.True(result < 0);
+
+                var toCompare2 = "כרמל";
+                size = Encoding.UTF8.GetByteCount(toCompare2);
+                stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(toCompare2, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.True(result < 0);
+
+                var toCompare3 = "אורן";
+                size = Encoding.UTF8.GetByteCount(toCompare3);
+                stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(toCompare3, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.True(result < 0);
+
+                size = Encoding.UTF8.GetByteCount(word1);
+                stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(word1, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.True(result > 0);
+
+                size = Encoding.UTF8.GetByteCount(word2);
+                stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(word2, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.True(result < 0);
+
+                size = Encoding.UTF8.GetByteCount(word3);
+                stringAsBytes = stackalloc byte[size];
+                Encoding.UTF8.GetBytes(word3, stringAsBytes);
+                result = UnmanagedString.CompareOrdinal(terms[2], stringAsBytes, Span<char>.Empty);
+                Assert.AreEqual(0, result);
+
+                result = terms[0].CompareTo(toCompare1);
+                Assert.True(result < 0);
+                result = terms[0].CompareTo(toCompare2);
+                Assert.True(result < 0);
+                result = terms[0].CompareTo(toCompare3);
+                Assert.True(result < 0);
+                result = terms[0].CompareTo(word1);
+                Assert.AreEqual(0, result);
+                result = terms[0].CompareTo(word2);
+                Assert.True(result < 0);
+                result = terms[0].CompareTo(word3);
+                Assert.True(result < 0);
+
+                result = terms[1].CompareTo(toCompare1);
+                Assert.AreEqual(0, result);
+                result = terms[1].CompareTo(toCompare2);
+                Assert.True(result < 0);
+                result = terms[1].CompareTo(toCompare3);
+                Assert.True(result > 0);
+                result = terms[1].CompareTo(word1);
+                Assert.True(result > 0);
+                result = terms[1].CompareTo(word2);
+                Assert.AreEqual(0, result);
+                result = terms[1].CompareTo(word3);
+                Assert.True(result > 0);
+
+                result = terms[2].CompareTo(toCompare1);
+                Assert.True(result < 0);
+                result = terms[2].CompareTo(toCompare2);
+                Assert.True(result < 0);
+                result = terms[2].CompareTo(toCompare3);
+                Assert.True(result < 0);
+                result = terms[2].CompareTo(word1);
+                Assert.True(result > 0);
+                result = terms[2].CompareTo(word2);
+                Assert.True(result < 0);
+                result = terms[2].CompareTo(word3);
+                Assert.AreEqual(0, result);
+            }
+        }
+
         private static unsafe void VerifyNonExistingTerms(UnmanagedStringArray terms)
         {
             using (var segment = new Segment(10))
@@ -297,7 +409,7 @@ namespace Lucene.Net.Search
                 const string biggerThan = "z";
 
                 var size = (ushort)Encoding.UTF8.GetByteCount(smallerThan);
-                segment.Add(size, out var position);
+                var position = segment.Add(size);
                 Encoding.UTF8.GetBytes(smallerThan, new Span<byte>(position + sizeof(ushort), size));
                 var smallerUnmanagedString = new UnmanagedString
                 {
@@ -308,7 +420,7 @@ namespace Lucene.Net.Search
                 Assert.AreEqual(-2, result);
 
                 size = (ushort)Encoding.UTF8.GetByteCount(biggerThan);
-                segment.Add(size, out position);
+                position = segment.Add(size);
                 Encoding.UTF8.GetBytes(biggerThan, new Span<byte>(position + sizeof(ushort), size));
                 var biggerUnmanagedString = new UnmanagedString
                 {

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -408,6 +408,78 @@ namespace Lucene.Net.Search
             }
         }
 
+        [Test]
+        public void Compare_Various_Length_Unmanaged_Strings()
+        {
+            using (var terms = new UnmanagedStringArray(64 * 4, startIndex: 0))
+            {
+                var strings = new List<string>();
+                for (var i = 0; i < 64; i++)
+                {
+                    strings.Add(GenerateLargeString(32, isAscii: true));
+                    strings.Add(GenerateLargeString(32, isAscii: false));
+                    strings.Add(GenerateLargeString(300, isAscii: true));
+                    strings.Add(GenerateLargeString(300, isAscii: false));
+                }
+
+                strings.Sort(StringComparer.Ordinal);
+
+                foreach (var str in strings)
+                {
+                    terms.Add(str.ToCharArray());
+                }
+
+                for (var i = 0; i < strings.Count; i++)
+                {
+                    var result = terms[i].CompareTo(strings[i]);
+                    Assert.AreEqual(0, result);
+
+                    // check that all subsequent strings are greater
+                    for (var j = i + 1; j < strings.Count; j++)
+                    {
+                        result = terms[j].CompareTo(strings[i]);
+                        Assert.True(result > 0);
+                    }
+
+                    // check that all preceding strings are less
+                    for (var j = i - 1; j >= 0; j--)
+                    {
+                        result = terms[j].CompareTo(strings[i]);
+                        Assert.True(result < 0);
+                    }
+                }
+            }
+        }
+
+        private static string GenerateLargeString(int size, bool isAscii)
+        {
+            var builder = new StringBuilder(size);
+            var random = new Random();
+
+            for (int i = 0; i < size; i++)
+            {
+                if (isAscii)
+                {
+                    // Generate random ASCII character (printable range: 32 to 126)
+                    builder.Append((char)random.Next(32, 127));
+                }
+                else
+                {
+                    // Generate random non-ASCII character (Unicode range: 128 to 65535)
+                    // Skipping surrogate ranges (0xD800 to 0xDFFF) to avoid invalid strings
+                    int nonAsciiCodePoint;
+                    do
+                    {
+                        nonAsciiCodePoint = random.Next(128, 65536);
+                    } while (nonAsciiCodePoint >= 0xD800 && nonAsciiCodePoint <= 0xDFFF);
+
+                    builder.Append((char)nonAsciiCodePoint);
+                }
+            }
+
+            return builder.ToString();
+        }
+
         private static void VerifyNonExistingTerms(UnmanagedStringArray terms)
         {
             using (var internalTerms = new UnmanagedStringArray(3, startIndex: 0))

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Text;
 using Lucene.Net.Index;
 using Lucene.Net.Util;
@@ -14,27 +13,27 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_All_Terms()
         {
-            var terms = new UnmanagedStringArray(11, startIndex: 1);
-
-            for (var letter = 'a'; letter <= 'j'; letter++)
+            using (var terms = new UnmanagedStringArray(11, startIndex: 1))
             {
-                terms.Add(new Span<char>(letter.ToString().ToCharArray()));
-            }
+                for (var letter = 'a'; letter <= 'j'; letter++)
+                {
+                    terms.Add(new Span<char>(letter.ToString().ToCharArray()));
+                }
 
-            for (var i = 1; i < terms.Length; i++)
-            {
-                var position = FieldComparator.BinarySearch(terms, terms[i]);
-                Assert.AreEqual(i, position);
-            }
+                for (var i = 1; i < terms.Length; i++)
+                {
+                    var position = FieldComparator.BinarySearch(terms, terms[i]);
+                    Assert.AreEqual(i, position);
+                }
 
-            VerifyNonExistingTerms(terms);
+                VerifyNonExistingTerms(terms);
+            }
         }
 
         [Test]
         public void Should_Find_With_Missing_Terms()
         {
             var terms = new UnmanagedStringArray(11, startIndex: 1);
-
             var count = 0;
             for (var letter = 'a'; letter <= 'j'; letter++)
             {
@@ -127,17 +126,19 @@ namespace Lucene.Net.Search
         [Test]
         public void Should_Find_Terms()
         {
-            var terms = new UnmanagedStringArray(char.MaxValue + 1, startIndex: 0);
-            for (int code = char.MinValue; code <= char.MaxValue; code++)
+            using (var terms = new UnmanagedStringArray(char.MaxValue + 1, startIndex: 0))
             {
-                char letter = (char)code;
-                terms.Add(new Span<char>([letter]));
-            }
+                for (int code = char.MinValue; code <= char.MaxValue; code++)
+                {
+                    char letter = (char)code;
+                    terms.Add(new Span<char>([letter]));
+                }
 
-            for (var i = 0; i < terms.Length; i++)
-            {
-                var position = FieldComparator.BinarySearch(terms, terms[i]);
-                Assert.AreEqual(i, position);
+                for (var i = 0; i < terms.Length; i++)
+                {
+                    var position = FieldComparator.BinarySearch(terms, terms[i]);
+                    Assert.AreEqual(i, position);
+                }
             }
         }
 
@@ -166,18 +167,20 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
-            foreach (var str in sortedStrings)
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
             {
-                terms.Add(new Span<char>(str.ToCharArray()));
-            }
+                foreach (var str in sortedStrings)
+                {
+                    terms.Add(new Span<char>(str.ToCharArray()));
+                }
 
-            for (var i = 0; i < terms.Length; i++)
-            {
-                var position = FieldComparator.BinarySearch(terms, terms[i]);
-                Assert.AreEqual(i, position);
+                for (var i = 0; i < terms.Length; i++)
+                {
+                    var position = FieldComparator.BinarySearch(terms, terms[i]);
+                    Assert.AreEqual(i, position);
 
-                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                    Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                }
             }
         }
 
@@ -206,18 +209,20 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
-            foreach (var str in sortedStrings)
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
             {
-                terms.Add(new Span<char>(str.ToCharArray()));
-            }
+                foreach (var str in sortedStrings)
+                {
+                    terms.Add(new Span<char>(str.ToCharArray()));
+                }
 
-            for (var i = 0; i < terms.Length; i++)
-            {
-                var position = FieldComparator.BinarySearch(terms, terms[i]);
-                Assert.AreEqual(i, position);
+                for (var i = 0; i < terms.Length; i++)
+                {
+                    var position = FieldComparator.BinarySearch(terms, terms[i]);
+                    Assert.AreEqual(i, position);
 
-                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                    Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                }
             }
         }
 
@@ -275,18 +280,20 @@ namespace Lucene.Net.Search
             var sortedStrings = new List<string>(uniqueStrings);
             sortedStrings.Sort(string.CompareOrdinal);
 
-            var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0);
-            foreach (var str in sortedStrings)
+            using (var terms = new UnmanagedStringArray(sortedStrings.Count + 1, startIndex: 0))
             {
-                terms.Add(new Span<char>(str.ToCharArray()));
-            }
+                foreach (var str in sortedStrings)
+                {
+                    terms.Add(new Span<char>(str.ToCharArray()));
+                }
 
-            for (var i = 0; i < terms.Length; i++)
-            {
-                var position = FieldComparator.BinarySearch(terms, terms[i]);
-                Assert.AreEqual(i, position);
+                for (var i = 0; i < terms.Length; i++)
+                {
+                    var position = FieldComparator.BinarySearch(terms, terms[i]);
+                    Assert.AreEqual(i, position);
 
-                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                    Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+                }
             }
         }
 
@@ -401,33 +408,20 @@ namespace Lucene.Net.Search
             }
         }
 
-        private static unsafe void VerifyNonExistingTerms(UnmanagedStringArray terms)
+        private static void VerifyNonExistingTerms(UnmanagedStringArray terms)
         {
-            using (var segment = new Segment(10))
+            using (var internalTerms = new UnmanagedStringArray(3, startIndex: 0))
             {
                 const string smallerThan = "A";
                 const string biggerThan = "z";
 
-                var size = (ushort)Encoding.UTF8.GetByteCount(smallerThan);
-                var position = segment.Add(size);
-                Encoding.UTF8.GetBytes(smallerThan, new Span<byte>(position + sizeof(ushort), size));
-                var smallerUnmanagedString = new UnmanagedString
-                {
-                    Start = position
-                };
+                internalTerms.Add(smallerThan.ToCharArray());
+                internalTerms.Add(biggerThan.ToCharArray());
 
-                var result = FieldComparator.BinarySearch(terms, smallerUnmanagedString);
+                var result = FieldComparator.BinarySearch(terms, internalTerms[0]);
                 Assert.AreEqual(-2, result);
 
-                size = (ushort)Encoding.UTF8.GetByteCount(biggerThan);
-                position = segment.Add(size);
-                Encoding.UTF8.GetBytes(biggerThan, new Span<byte>(position + sizeof(ushort), size));
-                var biggerUnmanagedString = new UnmanagedString
-                {
-                    Start = position
-                };
-
-                result = FieldComparator.BinarySearch(terms, biggerUnmanagedString);
+                result = FieldComparator.BinarySearch(terms, internalTerms[1]);
                 Assert.AreEqual(-12, result);
             }
         }

--- a/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/UnmanagedStringArrayTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Lucene.Net.Index;
 using Lucene.Net.Util;
@@ -120,6 +121,172 @@ namespace Lucene.Net.Search
             }
 
             VerifyNonExistingTerms(terms);
+        }
+
+        [Test]
+        public void Should_Find_Terms()
+        {
+            var terms = new UnmanagedStringArray(char.MaxValue + 1);
+            for (int code = char.MinValue; code <= char.MaxValue; code++)
+            {
+                char letter = (char)code;
+                terms.Add(new Span<char>([letter]));
+            }
+
+            for (var i = 0; i < terms.Length; i++)
+            {
+                var position = FieldComparator.BinarySearch(terms, terms[i]);
+                Assert.AreEqual(i, position);
+            }
+        }
+
+        [Test]
+        public void Should_Find_Terms_Random_Ascii_Strings()
+        {
+            var uniqueStrings = new HashSet<string>();
+            var random = new Random(Seed: 3117);
+
+            const int asciiStart = 0;
+            const int asciiEnd = 127;
+
+            while (uniqueStrings.Count < 64 * 1024)
+            {
+                var length = random.Next(1, 101);
+
+                var chars = new char[length];
+                for (var j = 0; j < length; j++)
+                {
+                    chars[j] = (char)random.Next(asciiStart, asciiEnd + 1);
+                }
+
+                uniqueStrings.Add(new string(chars));
+            }
+
+            var sortedStrings = new List<string>(uniqueStrings);
+            sortedStrings.Sort(string.CompareOrdinal);
+
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            foreach (var str in sortedStrings)
+            {
+                terms.Add(new Span<char>(str.ToCharArray()));
+            }
+
+            for (var i = 0; i < terms.Length; i++)
+            {
+                var position = FieldComparator.BinarySearch(terms, terms[i]);
+                Assert.AreEqual(i, position);
+
+                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+            }
+        }
+
+        [Test]
+        public void Should_Find_Terms_Random_Non_Ascii_Strings()
+        {
+            var uniqueStrings = new HashSet<string>();
+            var random = new Random(Seed: 3117);
+
+            const int unicodeStart = 0x0080;
+            const int unicodeEnd = 0xFFFF;
+
+            while (uniqueStrings.Count < 64 * 1024)
+            {
+                var length = random.Next(1, 101);
+
+                var chars = new char[length];
+                for (var j = 0; j < length; j++)
+                {
+                    chars[j] = (char)random.Next(unicodeStart, unicodeEnd + 1);
+                }
+
+                uniqueStrings.Add(new string(chars));
+            }
+
+            var sortedStrings = new List<string>(uniqueStrings);
+            sortedStrings.Sort(string.CompareOrdinal);
+
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            foreach (var str in sortedStrings)
+            {
+                terms.Add(new Span<char>(str.ToCharArray()));
+            }
+
+            for (var i = 0; i < terms.Length; i++)
+            {
+                var position = FieldComparator.BinarySearch(terms, terms[i]);
+                Assert.AreEqual(i, position);
+
+                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+            }
+        }
+
+        [Test]
+        public void Should_Find_Terms_Random_Strings()
+        {
+            var uniqueStrings = new HashSet<string>();
+            var random = new Random(Seed: 3117);
+
+            const int asciiStart = 0x00;
+            const int asciiEnd = 0x7F;
+
+            const int unicodeStart = 0x0080;
+            const int unicodeEnd = 0xFFFF;
+
+            while (uniqueStrings.Count < 64 * 1024)
+            {
+                var type = random.Next(3); // 0 = ASCII only, 1 = non-ASCII only, 2 = mixed
+
+                var length = random.Next(1, 101);
+                var chars = new char[length];
+
+                for (var j = 0; j < length; j++)
+                {
+                    switch (type)
+                    {
+                        case 0:
+                            // ascii only
+                            chars[j] = (char)random.Next(asciiStart, asciiEnd + 1);
+                            break;
+                        case 1:
+                            // non-ascii only
+                            chars[j] = (char)random.Next(unicodeStart, unicodeEnd + 1);
+                            break;
+                        default:
+                        {
+                            // randomly pick ascii or non-ascii for this character
+                            if (random.Next(2) == 0)
+                            {
+                                chars[j] = (char)random.Next(asciiStart, asciiEnd + 1);
+                            }
+                            else
+                            {
+                                chars[j] = (char)random.Next(unicodeStart, unicodeEnd + 1);
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                uniqueStrings.Add(new string(chars));
+            }
+
+            var sortedStrings = new List<string>(uniqueStrings);
+            sortedStrings.Sort(string.CompareOrdinal);
+
+            var terms = new UnmanagedStringArray(sortedStrings.Count + 1);
+            foreach (var str in sortedStrings)
+            {
+                terms.Add(new Span<char>(str.ToCharArray()));
+            }
+
+            for (var i = 0; i < terms.Length; i++)
+            {
+                var position = FieldComparator.BinarySearch(terms, terms[i]);
+                Assert.AreEqual(i, position);
+
+                Assert.AreEqual(sortedStrings[i], terms[i].ToString());
+            }
         }
 
         private static unsafe void VerifyNonExistingTerms(UnmanagedStringArray terms)

--- a/test/contrib/Lucene.Net.Contrib.FastVectorHighlighter.Tests/Lucene.Net.Contrib.FastVectorHighlighter.Tests.csproj
+++ b/test/contrib/Lucene.Net.Contrib.FastVectorHighlighter.Tests/Lucene.Net.Contrib.FastVectorHighlighter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeFrameworkVersion>3.1.3</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Lucene.Net.Contrib.FastVectorHighlighter.Tests</AssemblyName>

--- a/test/contrib/Lucene.Net.Contrib.Spatial.Tests/Lucene.Net.Contrib.Spatial.Tests.csproj
+++ b/test/contrib/Lucene.Net.Contrib.Spatial.Tests/Lucene.Net.Contrib.Spatial.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeFrameworkVersion>3.1.3</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Lucene.Net.Contrib.Spatial.Tests</AssemblyName>


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-23414/Order-by-unicode-characters-not-working

ASCII strings are stored as bytes.
Non-ASCII strings are stored as characters to ensure correct comparison of non-ASCII strings.