### PR TITLE
RavenDB-24810 - set the correct LangVersion

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version>3.0.54016</Version>
     <FileVersion>3.0.54016.0</FileVersion>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <DebugType>embedded</DebugType>
 
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Using `latest` for the `LangVersion` resulted in an NRE on runtime.
The null came from https://github.com/ravendb/lucenenet/blob/2e9b9cfb8be3eb8ea125f36b5a2acb24a577b8ea/src/Lucene.Net/Index/Term.cs#L69

This is most likely because of the backing field is with the name `field` and this is unsupported in dotnet 10 (might be also not supported in dotnet 9).