### PR TITLE
RavenDB-25416 - Reduce TopDocs memory footprint using ManagedScoreDocArray

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.60015</Version>
-    <FileVersion>3.0.60015</FileVersion>
+    <Version>3.0.60016</Version>
+    <FileVersion>3.0.60016</FileVersion>
     <LangVersion>12.0</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.60017</Version>
-    <FileVersion>3.0.60017</FileVersion>
+    <Version>3.0.60018</Version>
+    <FileVersion>3.0.60018</FileVersion>
     <LangVersion>12.0</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.60016</Version>
-    <FileVersion>3.0.60016</FileVersion>
+    <Version>3.0.60017</Version>
+    <FileVersion>3.0.60017</FileVersion>
     <LangVersion>12.0</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Search/FieldValueHitQueue.cs
+++ b/src/Lucene.Net/Search/FieldValueHitQueue.cs
@@ -214,7 +214,7 @@ namespace Lucene.Net.Search
 		/// </returns>
 		/// <seealso cref="Searchable.Search(Weight,Filter,int,Sort)">
 		/// </seealso>
-		internal virtual FieldDoc FillFields(Entry entry)
+		internal virtual (int Doc, float Score, IComparable[] fields) FillFields(Entry entry)
 		{
 			int n = comparators.Length;
 			System.IComparable[] fields = new System.IComparable[n];
@@ -223,7 +223,7 @@ namespace Lucene.Net.Search
 				fields[i] = comparators[i][entry.slot];
 			}
 			//if (maxscore > 1.0f) doc.score /= maxscore;   // normalize scores
-			return new FieldDoc(entry.Doc, entry.Score, fields);
+			return (entry.Doc, entry.Score, fields);
 		}
 		
 		/// <summary>Returns the SortFields being used by this hit queue. </summary>

--- a/src/Lucene.Net/Search/FieldValueHitQueue.cs
+++ b/src/Lucene.Net/Search/FieldValueHitQueue.cs
@@ -214,16 +214,16 @@ namespace Lucene.Net.Search
 		/// </returns>
 		/// <seealso cref="Searchable.Search(Weight,Filter,int,Sort)">
 		/// </seealso>
-		internal virtual (int Doc, float Score, IComparable[] fields) FillFields(Entry entry)
+		internal virtual IComparable[] GetFields(int slot)
 		{
 			int n = comparators.Length;
 			System.IComparable[] fields = new System.IComparable[n];
 			for (int i = 0; i < n; ++i)
 			{
-				fields[i] = comparators[i][entry.slot];
+				fields[i] = comparators[i][slot];
 			}
 			//if (maxscore > 1.0f) doc.score /= maxscore;   // normalize scores
-			return (entry.Doc, entry.Score, fields);
+			return fields;
 		}
 		
 		/// <summary>Returns the SortFields being used by this hit queue. </summary>

--- a/src/Lucene.Net/Search/IndexSearcher.cs
+++ b/src/Lucene.Net/Search/IndexSearcher.cs
@@ -191,11 +191,6 @@ namespace Lucene.Net.Search
 			return collector.TopDocs();
 		}
 		
-		public override TopFieldDocs Search(Weight weight, Filter filter, int nDocs, Sort sort, IState state)
-		{
-			return Search(weight, filter, nDocs, sort, true, state);
-		}
-		
 		/// <summary> Just like <see cref="Search(Weight, Filter, int, Sort)" />, but you choose
 		/// whether or not the fields in the returned <see cref="FieldDoc" /> instances
 		/// should be set by specifying fillFields.
@@ -206,15 +201,16 @@ namespace Lucene.Net.Search
 		/// <see cref="Search(Weight, Filter, Collector)" />.
 		/// <p/>
 		/// </summary>
-		public virtual TopFieldDocs Search(Weight weight, Filter filter, int nDocs, Sort sort, bool fillFields, IState state)
+		public override TopFieldDocs Search(Weight weight, Filter filter, int nDocs, Sort sort, bool fillFields, IState state)
 		{
             nDocs = Math.Min(nDocs, reader.MaxDoc);
 
-			TopFieldCollector collector2 = TopFieldCollector.Create(sort, nDocs, fillFields, fieldSortDoTrackScores, fieldSortDoMaxScore, !weight.GetScoresDocsOutOfOrder());
+			TopFieldCollector collector2 = TopFieldCollector.Create(sort, nDocs, fillFields, fieldSortDoTrackScores,
+                fieldSortDoMaxScore, !weight.GetScoresDocsOutOfOrder());
 			Search(weight, filter, collector2, state);
 			return (TopFieldDocs) collector2.TopDocs();
 		}
-		
+
 		public override void  Search(Weight weight, Filter filter, Collector collector, IState state)
 		{
 			

--- a/src/Lucene.Net/Search/MultiSearcher.cs
+++ b/src/Lucene.Net/Search/MultiSearcher.cs
@@ -266,12 +266,12 @@ namespace Lucene.Net.Search
 
             var lockObj = new object();
 			for (int i = 0; i < searchables.Length; i++)
-			{
+            {
                 // search each searcher
-                // use NullLock, we don't care about synchronization for these
-                TopDocs docs = MultiSearcherCallableNoSort(ThreadLock.NullLock, lockObj, searchables[i], weight, filter, nDocs, hq, i, starts, state);
-				totalHits += docs.TotalHits; // update totalHits
-			}
+				// use NullLock, we don't care about synchronization for these
+                using var docs = MultiSearcherCallableNoSort(ThreadLock.NullLock, lockObj, searchables[i], weight, filter, nDocs, hq, i, starts, state);
+                totalHits += docs.TotalHits; // update totalHits
+            }
 
             var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: false);
             var writer = scoreDocArray.GetBackwardsWriter();
@@ -296,14 +296,16 @@ namespace Lucene.Net.Search
 
 		    var lockObj = new object();
 			for (int i = 0; i < searchables.Length; i++)
-			{
-				// search each searcher
-                // use NullLock, we don't care about synchronization for these
-                TopFieldDocs docs = MultiSearcherCallableWithSort(ThreadLock.NullLock, lockObj, searchables[i], weight, filter, n, hq, sort,
-			                                          i, starts, state);
-			    totalHits += docs.TotalHits;
-				maxScore = System.Math.Max(maxScore, docs.MaxScore);
-			}
+            {
+                // search each searcher
+				// use NullLock, we don't care about synchronization for these
+                using TopFieldDocs docs = MultiSearcherCallableWithSort(ThreadLock.NullLock, lockObj, searchables[i],
+                    weight, filter, n, hq, sort,
+                    i, starts, state);
+
+                totalHits += docs.TotalHits;
+                maxScore = System.Math.Max(maxScore, docs.MaxScore);
+            }
 
             var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: true);
             var writer = scoreDocArray.GetBackwardsWriter();
@@ -460,6 +462,8 @@ namespace Lucene.Net.Search
                                                         var fields = docs.ScoreDocArray.Fields[index];
                                                         var fieldDoc = new FieldDoc(doc, score, fields);
                                                         fieldDoc.Doc += starts[i]; //convert doc
+                                                        index++;
+
                                                         //it would be so nice if we had a thread-safe insert
                                                         lock (lockObj)
                                                         {

--- a/src/Lucene.Net/Search/MultiSearcher.cs
+++ b/src/Lucene.Net/Search/MultiSearcher.cs
@@ -165,7 +165,7 @@ namespace Lucene.Net.Search
 				throw new System.NotSupportedException();
 			}
 			
-			public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state)
+			public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, bool fillFields, IState state)
 			{
 				throw new System.NotSupportedException();
 			}
@@ -287,7 +287,7 @@ namespace Lucene.Net.Search
 			return new TopDocs(totalHits, maxScore, scoreDocArray);
 		}
 		
-		public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state)
+		public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, bool fillFields, IState state)
 		{
 			var hq = new FieldDocSortedHitQueue(n);
 			int totalHits = 0;
@@ -426,7 +426,7 @@ namespace Lucene.Net.Search
         internal Func<ThreadLock, object, Searchable, Weight, Filter, int, FieldDocSortedHitQueue, Sort, int, int[], IState, TopFieldDocs>
             MultiSearcherCallableWithSort = (threadLock, lockObj, searchable, weight, filter, nDocs, hq, sort, i, starts, state) =>
 	                                            {
-	                                                TopFieldDocs docs = searchable.Search(weight, filter, nDocs, sort, state);
+	                                                TopFieldDocs docs = searchable.Search(weight, filter, nDocs, sort, fillFields: true, state);
                                                     // if one of the Sort fields is FIELD_DOC, need to fix its values, so that
                                                     // it will break ties by doc Id properly.  Otherwise, it will compare to
                                                     // 'relative' doc Ids, that belong to two different searchables.

--- a/src/Lucene.Net/Search/MultiSearcher.cs
+++ b/src/Lucene.Net/Search/MultiSearcher.cs
@@ -272,15 +272,19 @@ namespace Lucene.Net.Search
                 TopDocs docs = MultiSearcherCallableNoSort(ThreadLock.NullLock, lockObj, searchables[i], weight, filter, nDocs, hq, i, starts, state);
 				totalHits += docs.TotalHits; // update totalHits
 			}
+
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: false);
+            var writer = scoreDocArray.GetBackwardsWriter();
+
+            for (int i = hq.Size() - 1; i >= 0; i--)
+            {
+				var scoreDoc = hq.Pop();
+                writer.Write(scoreDoc.Doc, scoreDoc.Score);
+            }
+
+            float maxScore = (totalHits == 0) ? System.Single.NegativeInfinity : scoreDocArray[0].Score;
 			
-			ScoreDoc[] scoreDocs2 = new ScoreDoc[hq.Size()];
-			for (int i = hq.Size() - 1; i >= 0; i--)
-			// put docs in array
-				scoreDocs2[i] = hq.Pop();
-			
-			float maxScore = (totalHits == 0)?System.Single.NegativeInfinity:scoreDocs2[0].Score;
-			
-			return new TopDocs(totalHits, scoreDocs2, maxScore);
+			return new TopDocs(totalHits, maxScore, scoreDocArray);
 		}
 		
 		public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state)
@@ -300,17 +304,21 @@ namespace Lucene.Net.Search
 			    totalHits += docs.TotalHits;
 				maxScore = System.Math.Max(maxScore, docs.MaxScore);
 			}
+
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: true);
+            var writer = scoreDocArray.GetBackwardsWriter();
+
+            for (int i = hq.Size() - 1; i >= 0; i--)
+            {
+				var fieldDoc = hq.Pop();
+                writer.Write(i, (fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields));
+            }
 			
-			ScoreDoc[] scoreDocs2 = new ScoreDoc[hq.Size()];
-			for (int i = hq.Size() - 1; i >= 0; i--)
-			// put docs in array
-				scoreDocs2[i] = hq.Pop();
-			
-			return new TopFieldDocs(totalHits, scoreDocs2, hq.GetFields(), maxScore);
+			return new TopFieldDocs(totalHits, scoreDocArray, hq.GetFields(), maxScore);
 		}
 		
 		///<inheritdoc />
-		public override void  Search(Weight weight, Filter filter, Collector collector, IState state)
+		public override void Search(Weight weight, Filter filter, Collector collector, IState state)
 		{
 			for (int i = 0; i < searchables.Length; i++)
 			{
@@ -390,12 +398,14 @@ namespace Lucene.Net.Search
 	        (threadLock, lockObj, searchable, weight, filter, nDocs, hq, i, starts, state) =>
 	            {
 	                TopDocs docs = searchable.Search(weight, filter, nDocs, state);
-	                ScoreDoc[] scoreDocs = docs.ScoreDocs;
-                    for(int j = 0; j < scoreDocs.Length; j++) // merge scoreDocs into hq
+                    var reader = docs.ScoreDocArray.GetReader(start: 0);
+
+                    while (reader.Read(out int doc, out float score))
                     {
-                        ScoreDoc scoreDoc = scoreDocs[j];
+                        ScoreDoc scoreDoc = new ScoreDoc(doc, score);
                         scoreDoc.Doc += starts[i]; //convert doc
                         //it would be so nice if we had a thread-safe insert
+
                         try
                         {
                             threadLock.Enter(lockObj);
@@ -407,6 +417,7 @@ namespace Lucene.Net.Search
                             threadLock.Exit(lockObj);
                         }
                     }
+
 	                return docs;
 	            };
 
@@ -422,10 +433,11 @@ namespace Lucene.Net.Search
                                                         if (docs.fields.Array[j + docs.fields.Offset].Type == SortField.DOC)
                                                         {
                                                             // iterate over the score docs and change their fields value
-                                                            for (int j2 = 0; j2 < docs.ScoreDocs.Length; j2++)
+
+                                                            for (int j2 = 0; j2 < docs.ScoreDocArray.Length; j2++)
                                                             {
-                                                                FieldDoc fd = (FieldDoc) docs.ScoreDocs[j2];
-                                                                fd.fields[j] = (int)fd.fields[j] + starts[i];
+                                                                var comparableFor = docs.ScoreDocArray.Fields[j2];
+                                                                comparableFor[j] = (int)comparableFor[j] + starts[i];
                                                             }
                                                             break;
                                                         }
@@ -440,10 +452,13 @@ namespace Lucene.Net.Search
                                                         threadLock.Exit(lockObj);
 	                                                }
 
-	                                                ScoreDoc[] scoreDocs = docs.ScoreDocs;
-                                                    for (int j = 0; j < scoreDocs.Length; j++) // merge scoreDocs into hq
+                                                    var reader = docs.ScoreDocArray.GetReader(start: 0);
+                                                    var index = 0;
+
+                                                    while (reader.Read(out int doc, out float score))
                                                     {
-                                                        FieldDoc fieldDoc = (FieldDoc) scoreDocs[j];
+                                                        var fields = docs.ScoreDocArray.Fields[index];
+                                                        var fieldDoc = new FieldDoc(doc, score, fields);
                                                         fieldDoc.Doc += starts[i]; //convert doc
                                                         //it would be so nice if we had a thread-safe insert
                                                         lock (lockObj)
@@ -453,6 +468,7 @@ namespace Lucene.Net.Search
 
                                                         }
                                                     }
+
 	                                                return docs;
 	                                            };
 	}

--- a/src/Lucene.Net/Search/MultiSearcher.cs
+++ b/src/Lucene.Net/Search/MultiSearcher.cs
@@ -313,7 +313,7 @@ namespace Lucene.Net.Search
             for (int i = hq.Size() - 1; i >= 0; i--)
             {
 				var fieldDoc = hq.Pop();
-                writer.Write(i, (fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields));
+                writer.Write(fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields);
             }
 			
 			return new TopFieldDocs(totalHits, scoreDocArray, hq.GetFields(), maxScore);

--- a/src/Lucene.Net/Search/MultiSearcher.cs
+++ b/src/Lucene.Net/Search/MultiSearcher.cs
@@ -273,7 +273,7 @@ namespace Lucene.Net.Search
                 totalHits += docs.TotalHits; // update totalHits
             }
 
-            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: false);
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), hasFields: false);
             var writer = scoreDocArray.GetBackwardsWriter();
 
             for (int i = hq.Size() - 1; i >= 0; i--)
@@ -307,7 +307,7 @@ namespace Lucene.Net.Search
                 maxScore = System.Math.Max(maxScore, docs.MaxScore);
             }
 
-            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: true);
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), hasFields: true);
             var writer = scoreDocArray.GetBackwardsWriter();
 
             for (int i = hq.Size() - 1; i >= 0; i--)
@@ -435,11 +435,11 @@ namespace Lucene.Net.Search
                                                         if (docs.fields.Array[j + docs.fields.Offset].Type == SortField.DOC)
                                                         {
                                                             // iterate over the score docs and change their fields value
+                                                            var fieldsReader = docs.ScoreDocArray.GetReader(start: 0);
 
-                                                            for (int j2 = 0; j2 < docs.ScoreDocArray.Length; j2++)
+                                                            while (fieldsReader.Read(out _, out _, out var fields))
                                                             {
-                                                                var comparableFor = docs.ScoreDocArray.Fields[j2];
-                                                                comparableFor[j] = (int)comparableFor[j] + starts[i];
+                                                                fields[j] = (int)fields[j] + starts[i];
                                                             }
                                                             break;
                                                         }
@@ -457,9 +457,8 @@ namespace Lucene.Net.Search
                                                     var reader = docs.ScoreDocArray.GetReader(start: 0);
                                                     var index = 0;
 
-                                                    while (reader.Read(out int doc, out float score))
+                                                    while (reader.Read(out int doc, out float score, out IComparable[] fields))
                                                     {
-                                                        var fields = docs.ScoreDocArray.Fields[index];
                                                         var fieldDoc = new FieldDoc(doc, score, fields);
                                                         fieldDoc.Doc += starts[i]; //convert doc
                                                         index++;

--- a/src/Lucene.Net/Search/ParallelMultiSearcher.cs
+++ b/src/Lucene.Net/Search/ParallelMultiSearcher.cs
@@ -152,7 +152,7 @@ namespace Lucene.Net.Search
 		/// Searchable, waits for each search to complete and merges
 		/// the results back together.
 		/// </summary>
-		public override TopFieldDocs Search(Weight weight, Filter filter, int nDocs, Sort sort, IState state)
+		public override TopFieldDocs Search(Weight weight, Filter filter, int nDocs, Sort sort, bool fillFields, IState state)
 		{
             if (sort == null) throw new ArgumentNullException("sort");
 

--- a/src/Lucene.Net/Search/ParallelMultiSearcher.cs
+++ b/src/Lucene.Net/Search/ParallelMultiSearcher.cs
@@ -18,7 +18,6 @@
 #if !NET35
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using Lucene.Net.Store;
@@ -136,11 +135,17 @@ namespace Lucene.Net.Search
                 maxScore = Math.Max(maxScore, topDocs.MaxScore);
             }
 
-            ScoreDoc[] scoreDocs = new ScoreDoc[hq.Size()];
-            for (int i = hq.Size() - 1; i >= 0; i--) // put docs in array
-                scoreDocs[i] = hq.Pop();
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: false);
 
-		    return new TopDocs(totalHits, scoreDocs, maxScore);
+            var writer = scoreDocArray.GetBackwardsWriter();
+
+            for (int i = hq.Size() - 1; i >= 0; i--)
+            {
+                var scoreDoc = hq.Pop();
+                writer.Write(scoreDoc.Doc, scoreDoc.Score);
+            }
+
+		    return new TopDocs(totalHits, maxScore, scoreDocArray);
 		}
 		
 		/// <summary> A search implementation allowing sorting which spans a new thread for each
@@ -174,11 +179,16 @@ namespace Lucene.Net.Search
                 maxScore = Math.Max(maxScore, topFieldDocs.MaxScore);
             }
 
-            ScoreDoc[] scoreDocs = new ScoreDoc[hq.Size()];
-            for (int i = hq.Size() - 1; i >= 0; i--)
-                scoreDocs[i] = hq.Pop();
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: true);
+            var writer = scoreDocArray.GetBackwardsWriter();
 
-		    return new TopFieldDocs(totalHits, scoreDocs, hq.GetFields(), maxScore);
+            for (int i = hq.Size() - 1; i >= 0; i--)
+            {
+				var fieldDoc = hq.Pop();
+                writer.Write(i, (fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields));
+
+            }
+		    return new TopFieldDocs(totalHits, scoreDocArray, hq.GetFields(), maxScore);
 		}
 		
 		/// <summary>Lower-level search API.

--- a/src/Lucene.Net/Search/ParallelMultiSearcher.cs
+++ b/src/Lucene.Net/Search/ParallelMultiSearcher.cs
@@ -135,7 +135,7 @@ namespace Lucene.Net.Search
                 maxScore = Math.Max(maxScore, topDocs.MaxScore);
             }
 
-            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: false);
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), hasFields: false);
 
             var writer = scoreDocArray.GetBackwardsWriter();
 
@@ -179,7 +179,7 @@ namespace Lucene.Net.Search
                 maxScore = Math.Max(maxScore, topFieldDocs.MaxScore);
             }
 
-            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), fillFields: true);
+            var scoreDocArray = new ManagedScoreDocArray(hq.Size(), hasFields: true);
             var writer = scoreDocArray.GetBackwardsWriter();
 
             for (int i = hq.Size() - 1; i >= 0; i--)

--- a/src/Lucene.Net/Search/ParallelMultiSearcher.cs
+++ b/src/Lucene.Net/Search/ParallelMultiSearcher.cs
@@ -185,7 +185,7 @@ namespace Lucene.Net.Search
             for (int i = hq.Size() - 1; i >= 0; i--)
             {
 				var fieldDoc = hq.Pop();
-                writer.Write(i, (fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields));
+                writer.Write(fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields);
 
             }
 		    return new TopFieldDocs(totalHits, scoreDocArray, hq.GetFields(), maxScore);

--- a/src/Lucene.Net/Search/Searchable.cs
+++ b/src/Lucene.Net/Search/Searchable.cs
@@ -165,6 +165,6 @@ namespace Lucene.Net.Search
 		/// 
 		/// </summary>
 		/// <throws>  BooleanQuery.TooManyClauses </throws>
-		TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state);
+		TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, bool fillFields, IState state);
 	}
 }

--- a/src/Lucene.Net/Search/Searcher.cs
+++ b/src/Lucene.Net/Search/Searcher.cs
@@ -57,9 +57,25 @@ namespace Lucene.Net.Search
 		/// <throws>  BooleanQuery.TooManyClauses </throws>
 		public virtual TopFieldDocs Search(Query query, Filter filter, int n, Sort sort, IState state)
 		{
-			return Search(CreateWeight(query, state), filter, n, sort, state);
+			return Search(CreateWeight(query, state), filter, n, sort, fillFields: true, state);
 		}
 		
+        /// <summary>Search implementation with arbitrary sorting.  Finds
+        /// the top <c>n</c> hits for <c>query</c>, applying
+        /// <c>filter</c> if non-null, and sorting the hits by the criteria in
+        /// <c>sort</c>.
+        /// <c>fillFields</c>.
+        /// 
+        /// <p/>NOTE: this does not compute scores by default; use
+        /// <see cref="IndexSearcher.SetDefaultFieldSortScoring(bool,bool)" /> to enable scoring.
+        /// 
+        /// </summary>
+        /// <throws>  BooleanQuery.TooManyClauses </throws>
+        public TopFieldDocs Search(Query query, Filter filter, int n, Sort sort, bool fillFields, IState state)
+        {
+            return Search(CreateWeight(query, state), filter, n, sort, fillFields, state);
+        }
+
 		/// <summary>Lower-level search API.
 		/// 
 		/// <p/><see cref="Collector.Collect(int)" /> is called for every matching document.
@@ -230,7 +246,7 @@ namespace Lucene.Net.Search
 	    public abstract Document Doc(int docid, FieldSelector fieldSelector, IState state);
 		public abstract Query Rewrite(Query query, IState state);
 		public abstract Explanation Explain(Weight weight, int doc, IState state);
-		public abstract TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state);
+		public abstract TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, bool fillFields, IState state);
 		/* End patch for GCJ bug #15411. */
 	}
 }

--- a/src/Lucene.Net/Search/Searcher.cs
+++ b/src/Lucene.Net/Search/Searcher.cs
@@ -59,13 +59,17 @@ namespace Lucene.Net.Search
 		{
 			return Search(CreateWeight(query, state), filter, n, sort, fillFields: true, state);
 		}
-		
+
         /// <summary>Search implementation with arbitrary sorting.  Finds
         /// the top <c>n</c> hits for <c>query</c>, applying
         /// <c>filter</c> if non-null, and sorting the hits by the criteria in
         /// <c>sort</c>.
-        /// <c>fillFields</c>.
-        /// 
+        /// If <paramref name="fillFields"/> is <c>true</c>, the returned
+        /// <see cref="TopFieldDocs"/> will have the sort field values filled in for each hit
+        /// (in the corresponding <see cref="FieldDoc"/> instances); if <c>false</c>, these
+        /// per-hit sort values are not computed, which can save time and memory when you
+        /// do not need access to the sort values.
+        ///  
         /// <p/>NOTE: this does not compute scores by default; use
         /// <see cref="IndexSearcher.SetDefaultFieldSortScoring(bool,bool)" /> to enable scoring.
         /// 

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -16,34 +16,29 @@
  */
 
 using System;
+using System.Collections.Generic;
+using Lucene.Net.Util;
 
 namespace Lucene.Net.Search
 {
-
     /// <summary> Represents hits returned by <see cref="Searcher.Search(Query,Filter,int)" />
     /// and <see cref="Searcher.Search(Query,int)" />
     /// </summary>
 
-        [Serializable]
-    public class TopDocs
-	{
-		private int _totalHits;
+    [Serializable]
+    public class TopDocs : IDisposable
+    {
+        private int _totalHits;
         private ScoreDoc[] _scoreDocs;
         private float _maxScore;
+
+        public ManagedScoreDocArray ScoreDocArray { get; }
 
         /// <summary>The total number of hits for the query.</summary>
         public int TotalHits
         {
             get { return _totalHits; }
             set { _totalHits = value; }
-        }
-
-        /// <summary>The top hits for the query. </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public ScoreDoc[] ScoreDocs
-        {
-            get { return _scoreDocs; }
-            set { _scoreDocs = value; }
         }
 
         /// <summary>
@@ -55,18 +50,52 @@ namespace Lucene.Net.Search
             get { return _maxScore; }
             set { _maxScore = value; }
         }
-		
-		/// <summary>Constructs a TopDocs with a default maxScore=Float.NaN. </summary>
-		internal TopDocs(int totalHits, ScoreDoc[] scoreDocs):this(totalHits, scoreDocs, float.NaN)
-		{
-		}
-		
-		/// <summary></summary>
-		public TopDocs(int totalHits, ScoreDoc[] scoreDocs, float maxScore)
-		{
-			this.TotalHits = totalHits;
-			this.ScoreDocs = scoreDocs;
-			this.MaxScore = maxScore;
-		}
-	}
+
+        public TopDocs()
+        {
+            ScoreDocArray = new ManagedScoreDocArray();
+        }
+
+        public TopDocs(int totalHits, float maxScore, ManagedScoreDocArray scoreDocArray)
+        {
+            TotalHits = totalHits;
+            MaxScore = maxScore;
+            ScoreDocArray = scoreDocArray;
+        }
+
+        public (int Doc, float Score) GetRawValues(int index)
+        {
+            var cds = ScoreDocArray[index];
+            return (cds.Doc, cds.Score);
+        }
+
+        // **************************************************************************** //
+        /// <summary>The top hits for the query. </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public ScoreDoc[] ScoreDocs
+        {
+            get
+            {
+                if (_scoreDocs == null)
+                {
+                    var reader = ScoreDocArray.GetReader(0);
+                    var list = new List<ScoreDoc>();
+
+                    while (reader.Read(out var doc, out var score))
+                    {
+                        list.Add(new ScoreDoc(doc, score));
+                    }
+
+                    _scoreDocs = list.ToArray();
+                }
+                return _scoreDocs;
+            }
+        }
+        // **************************************************************************** //
+
+        public void Dispose()
+        {
+            ScoreDocArray?.Dispose();
+        }
+    }
 }

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -51,11 +51,6 @@ namespace Lucene.Net.Search
             set { _maxScore = value; }
         }
 
-        public TopDocs()
-        {
-            ScoreDocArray = new ManagedScoreDocArray();
-        }
-
         public TopDocs(int totalHits, float maxScore, ManagedScoreDocArray scoreDocArray)
         {
             TotalHits = totalHits;

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -69,9 +69,17 @@ namespace Lucene.Net.Search
             return (cds.Doc, cds.Score);
         }
 
-        // **************************************************************************** //
         /// <summary>The top hits for the query. </summary>
+        /// <remarks>
+        /// <para>**WARNING:** This property materializes the entire ScoreDoc collection 
+        /// into a standard array, which can be **inefficient and memory-intensive** /// for large result sets. **Do not use this property in production code.**</para>
+        /// <para>This property is intended only for **testing and debugging** /// or when working with small, verified result sets.</para>
+        /// <para>For production use, utilize the efficient <see cref="ScoreDocArray"/> 
+        /// property and its associated reader methods (like <see cref="GetRawValues(int)"/>)
+        /// to access the scores without full materialization.</para>
+        /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        [Obsolete("This property is for testing/debugging ONLY and should not be used in production due to potential memory/performance issues. Use the ScoreDocArray property instead.", error: false)]
         public ScoreDoc[] ScoreDocs
         {
             get
@@ -91,7 +99,6 @@ namespace Lucene.Net.Search
                 return _scoreDocs;
             }
         }
-        // **************************************************************************** //
 
         public void Dispose()
         {

--- a/src/Lucene.Net/Search/TopDocs.cs
+++ b/src/Lucene.Net/Search/TopDocs.cs
@@ -63,19 +63,12 @@ namespace Lucene.Net.Search
             ScoreDocArray = scoreDocArray;
         }
 
-        public (int Doc, float Score) GetRawValues(int index)
-        {
-            var cds = ScoreDocArray[index];
-            return (cds.Doc, cds.Score);
-        }
-
         /// <summary>The top hits for the query. </summary>
         /// <remarks>
         /// <para>**WARNING:** This property materializes the entire ScoreDoc collection 
         /// into a standard array, which can be **inefficient and memory-intensive** /// for large result sets. **Do not use this property in production code.**</para>
         /// <para>This property is intended only for **testing and debugging** /// or when working with small, verified result sets.</para>
         /// <para>For production use, utilize the efficient <see cref="ScoreDocArray"/> 
-        /// property and its associated reader methods (like <see cref="GetRawValues(int)"/>)
         /// to access the scores without full materialization.</para>
         /// </remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]

--- a/src/Lucene.Net/Search/TopDocsCollector.cs
+++ b/src/Lucene.Net/Search/TopDocsCollector.cs
@@ -31,7 +31,7 @@ namespace Lucene.Net.Search
 		
 		// This is used in case topDocs() is called with illegal parameters, or there
 		// simply aren't (enough) results.
-		protected internal static readonly TopDocs EMPTY_TOPDOCS = new TopDocs(0, System.Single.NaN, new ManagedScoreDocArray());
+		protected internal static readonly TopDocs EMPTY_TOPDOCS = new TopDocs(0, System.Single.NaN, ManagedScoreDocArray.Empty);
 		
 		/// <summary> The priority queue which holds the top documents. Note that different
 		/// implementations of PriorityQueue give different meaning to 'top documents'.

--- a/src/Lucene.Net/Search/TopDocsCollector.cs
+++ b/src/Lucene.Net/Search/TopDocsCollector.cs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-using System;
 using Lucene.Net.Util;
 
 namespace Lucene.Net.Search
@@ -32,7 +31,7 @@ namespace Lucene.Net.Search
 		
 		// This is used in case topDocs() is called with illegal parameters, or there
 		// simply aren't (enough) results.
-		protected internal static readonly TopDocs EMPTY_TOPDOCS = new TopDocs(0, new ScoreDoc[0], System.Single.NaN);
+		protected internal static readonly TopDocs EMPTY_TOPDOCS = new TopDocs(0, System.Single.NaN, new ManagedScoreDocArray());
 		
 		/// <summary> The priority queue which holds the top documents. Note that different
 		/// implementations of PriorityQueue give different meaning to 'top documents'.
@@ -52,12 +51,13 @@ namespace Lucene.Net.Search
 		/// <summary> Populates the results array with the ScoreDoc instaces. This can be
 		/// overridden in case a different ScoreDoc type should be returned.
 		/// </summary>
-		protected internal virtual void  PopulateResults(ScoreDoc[] results, int howMany)
+		protected internal virtual void PopulateResults(ManagedScoreDocArray.BackwardsWriter writer, int howMany)
 		{
-			for (int i = howMany - 1; i >= 0; i--)
-			{
-				results[i] = pq.Pop();
-			}
+			for (var i = howMany - 1; i >= 0; i--)
+            {
+                var scoreDoc = pq.Pop();
+                writer.Write(scoreDoc.Doc, scoreDoc.Score);
+            }
 		}
 
         /// <summary> Returns a <see cref="Lucene.Net.Search.TopDocs" /> instance containing the given results. If
@@ -65,10 +65,10 @@ namespace Lucene.Net.Search
 		/// either because there were 0 calls to collect() or because the arguments to
 		/// topDocs were invalid.
 		/// </summary>
-		public /*protected internal*/ virtual TopDocs NewTopDocs(ScoreDoc[] results, int start)
-		{
-			return results == null?EMPTY_TOPDOCS:new TopDocs(internalTotalHits, results);
-		}
+		public /*protected internal*/ virtual TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
+        {
+            return scoreDocArray == null ? EMPTY_TOPDOCS : new TopDocs(internalTotalHits, maxScore: float.NaN, scoreDocArray);
+        }
 
 	    /// <summary>The total number of documents that matched this query. </summary>
 	    public virtual int TotalHits
@@ -76,8 +76,10 @@ namespace Lucene.Net.Search
 	        get { return internalTotalHits; }
 	    }
 
-	    /// <summary>Returns the top docs that were collected by this collector. </summary>
-		public TopDocs TopDocs()
+        public virtual bool FillFields => false;
+
+        /// <summary>Returns the top docs that were collected by this collector. </summary>
+        public TopDocs TopDocs()
 		{
 			// In case pq was populated with sentinel values, there might be less
 			// results than pq.size(). Therefore return all results until either
@@ -134,7 +136,7 @@ namespace Lucene.Net.Search
 			
 			// We know that start < pqsize, so just fix howMany. 
 			howMany = System.Math.Min(size - start, howMany);
-			ScoreDoc[] results = new ScoreDoc[howMany];
+            var managedArray = new ManagedScoreDocArray(howMany, FillFields);
 			
 			// pq's pop() returns the 'least' element in the queue, therefore need
 			// to discard the first ones, until we reach the requested range.
@@ -145,11 +147,13 @@ namespace Lucene.Net.Search
 			{
 				pq.Pop();
 			}
+
+            var writer = managedArray.GetBackwardsWriter();
+
+            // Get the requested results from pq.
+            PopulateResults(writer, howMany);
 			
-			// Get the requested results from pq.
-			PopulateResults(results, howMany);
-			
-			return NewTopDocs(results, start);
+			return NewTopDocs(managedArray, start);
 		}
 	}
 }

--- a/src/Lucene.Net/Search/TopFieldCollector.cs
+++ b/src/Lucene.Net/Search/TopFieldCollector.cs
@@ -946,8 +946,6 @@ namespace Lucene.Net.Search
 		    }
 		}
 
-        private static readonly ManagedScoreDocArray EMPTY_SCOREDOCS = new();
-		
 		private bool fillFields;
 
         public override bool FillFields => fillFields;
@@ -1104,8 +1102,9 @@ namespace Lucene.Net.Search
 				// avoid casting if unnecessary.
 				FieldValueHitQueue queue = (FieldValueHitQueue) pq;
 				for (var i = howMany - 1; i >= 0; i--)
-				{
-                    writer.Write(i, queue.FillFields(queue.Pop()));
+                {
+                    var entry = queue.Pop();
+                    writer.Write(entry.Doc, entry.Score, queue.GetFields(entry.slot));
 				}
 			}
 			else
@@ -1122,7 +1121,7 @@ namespace Lucene.Net.Search
 		{
 			if (scoreDocArray == null)
 			{
-                scoreDocArray = EMPTY_SCOREDOCS;
+                scoreDocArray = ManagedScoreDocArray.Empty;
 				// Set maxScore to NaN, in case this is a maxScore tracking collector.
 				maxScore = System.Single.NaN;
 			}

--- a/src/Lucene.Net/Search/TopFieldCollector.cs
+++ b/src/Lucene.Net/Search/TopFieldCollector.cs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-using System;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
 using IndexReader = Lucene.Net.Index.IndexReader;
@@ -946,12 +945,14 @@ namespace Lucene.Net.Search
 		        get { return true; }
 		    }
 		}
-		
-		private static readonly ScoreDoc[] EMPTY_SCOREDOCS = new ScoreDoc[0];
+
+        private static readonly ManagedScoreDocArray EMPTY_SCOREDOCS = new();
 		
 		private bool fillFields;
-		
-		/*
+
+        public override bool FillFields => fillFields;
+
+        /*
 		* Stores the maximum score value encountered, needed for normalizing. If
 		* document scores are not tracked, this value is initialized to NaN.
 		*/
@@ -1096,38 +1097,38 @@ namespace Lucene.Net.Search
 		* topDocs(int, int) calls them to return the results.
 		*/
 		
-		protected internal override void  PopulateResults(ScoreDoc[] results, int howMany)
+		protected internal override void PopulateResults(ManagedScoreDocArray.BackwardsWriter writer, int howMany)
 		{
 			if (fillFields)
 			{
 				// avoid casting if unnecessary.
 				FieldValueHitQueue queue = (FieldValueHitQueue) pq;
-				for (int i = howMany - 1; i >= 0; i--)
+				for (var i = howMany - 1; i >= 0; i--)
 				{
-					results[i] = queue.FillFields(queue.Pop());
+                    writer.Write(i, queue.FillFields(queue.Pop()));
 				}
 			}
 			else
 			{
-				for (int i = howMany - 1; i >= 0; i--)
+				for (var i = howMany - 1; i >= 0; i--)
 				{
-					Entry entry = pq.Pop();
-					results[i] = new FieldDoc(entry.Doc, entry.Score);
+					var entry = pq.Pop();
+					writer.Write(entry.Doc, entry.Score);
 				}
 			}
 		}
 		
-		public /*protected internal*/ override TopDocs NewTopDocs(ScoreDoc[] results, int start)
+		public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 		{
-			if (results == null)
+			if (scoreDocArray == null)
 			{
-				results = EMPTY_SCOREDOCS;
+                scoreDocArray = EMPTY_SCOREDOCS;
 				// Set maxScore to NaN, in case this is a maxScore tracking collector.
 				maxScore = System.Single.NaN;
 			}
 			
 			// If this is a maxScoring tracking collector and there were no results, 
-			return new TopFieldDocs(internalTotalHits, results, ((FieldValueHitQueue) pq).GetFields(), maxScore);
+			return new TopFieldDocs(internalTotalHits, scoreDocArray, ((FieldValueHitQueue) pq).GetFields(), maxScore);
 		}
 
 	    public override bool AcceptsDocsOutOfOrder

--- a/src/Lucene.Net/Search/TopFieldCollector.cs
+++ b/src/Lucene.Net/Search/TopFieldCollector.cs
@@ -1117,7 +1117,7 @@ namespace Lucene.Net.Search
 			}
 		}
 		
-		public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
+		public override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 		{
 			if (scoreDocArray == null)
 			{

--- a/src/Lucene.Net/Search/TopFieldDocs.cs
+++ b/src/Lucene.Net/Search/TopFieldDocs.cs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+using Lucene.Net.Util;
 using System;
 
 namespace Lucene.Net.Search
@@ -24,7 +25,7 @@ namespace Lucene.Net.Search
     /// Represents hits returned by <see cref="Searcher.Search(Query,Filter,int,Sort)" />.
     /// </summary>
 
-        [Serializable]
+    [Serializable]
     public class TopFieldDocs:TopDocs
 	{
 		
@@ -40,7 +41,7 @@ namespace Lucene.Net.Search
 		/// </param>
 		/// <param name="maxScore">  The maximum score encountered.
 		/// </param>
-		public TopFieldDocs(int totalHits, ScoreDoc[] scoreDocs, ArraySegment<SortField> fields, float maxScore):base(totalHits, scoreDocs, maxScore)
+        public TopFieldDocs(int totalHits, ManagedScoreDocArray scoreDocArray, ArraySegment<SortField> fields, float maxScore) : base(totalHits, maxScore, scoreDocArray)
 		{
 			this.fields = fields;
 		}

--- a/src/Lucene.Net/Search/TopScoreDocCollector.cs
+++ b/src/Lucene.Net/Search/TopScoreDocCollector.cs
@@ -136,7 +136,7 @@ namespace Lucene.Net.Search
 			pqTop = pq.Top();
 		}
 		
-		public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
+		public override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 		{
 			if (scoreDocArray == null)
 			{

--- a/src/Lucene.Net/Search/TopScoreDocCollector.cs
+++ b/src/Lucene.Net/Search/TopScoreDocCollector.cs
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-using System;
 using Lucene.Net.Store;
+using Lucene.Net.Util;
 using IndexReader = Lucene.Net.Index.IndexReader;
 
 namespace Lucene.Net.Search
@@ -136,9 +136,9 @@ namespace Lucene.Net.Search
 			pqTop = pq.Top();
 		}
 		
-		public /*protected internal*/ override TopDocs NewTopDocs(ScoreDoc[] results, int start)
+		public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 		{
-			if (results == null)
+			if (scoreDocArray == null)
 			{
 				return EMPTY_TOPDOCS;
 			}
@@ -150,7 +150,7 @@ namespace Lucene.Net.Search
 			float maxScore = System.Single.NaN;
 			if (start == 0)
 			{
-				maxScore = results[0].Score;
+				maxScore = scoreDocArray[0].Score;
 			}
 			else
 			{
@@ -161,7 +161,7 @@ namespace Lucene.Net.Search
 				maxScore = pq.Pop().Score;
 			}
 			
-			return new TopDocs(internalTotalHits, results, maxScore);
+			return new TopDocs(internalTotalHits, maxScore, scoreDocArray);
 		}
 		
 		public override void SetNextReader(IndexReader reader, int base_Renamed, IState state)

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -229,6 +229,10 @@ public class ManagedScoreDocArray : IDisposable
 
     public void Dispose()
     {
+        // never dispose the static Empty instance
+        if (ReferenceEquals(this, Empty))
+            return;
+
         GC.SuppressFinalize(this);
 
         foreach (var seg in _segments)

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -268,11 +268,12 @@ public class ManagedScoreDocArray : IDisposable
 
     public BackwardsWriter GetBackwardsWriter() => new(this);
 
-    public struct BackwardsWriter
+    public ref struct BackwardsWriter
     {
         private readonly ManagedScoreDocArray _parent;
-        private long[] _currentPacked;
-        private IComparable[][] _currentFields;
+        private ref int _intStart;
+        private ref IComparable[] _fieldsStart;
+        private bool _hasFields;
 
         private int _segIndex;
         private int _indexInSegment;
@@ -280,9 +281,14 @@ public class ManagedScoreDocArray : IDisposable
         public BackwardsWriter(ManagedScoreDocArray parent)
         {
             _parent = parent;
+            _hasFields = false;
 
             if (_parent.Length == 0)
+            {
+                _intStart = ref Unsafe.NullRef<int>();
+                _fieldsStart = ref Unsafe.NullRef<IComparable[]>();
                 return;
+            }
 
             int startIndex = parent._length - 1;
 
@@ -300,8 +306,17 @@ public class ManagedScoreDocArray : IDisposable
             }
 
             var seg = _parent._segments[_segIndex];
-            _currentPacked = seg.PackedDocsAndScores;
-            _currentFields = seg.Fields;
+            _intStart = ref Unsafe.As<long, int>(ref MemoryMarshal.GetArrayDataReference(seg.PackedDocsAndScores));
+
+            if (seg.Fields != null)
+            {
+                _fieldsStart = ref MemoryMarshal.GetArrayDataReference(seg.Fields);
+                _hasFields = true;
+            }
+            else
+            {
+                _fieldsStart = ref Unsafe.NullRef<IComparable[]>();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -312,17 +327,13 @@ public class ManagedScoreDocArray : IDisposable
 
             if (_indexInSegment >= 0)
             {
-                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
-                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
-
                 int offset = _indexInSegment * 2;
-                Unsafe.Add(ref intStart, offset) = doc;
-                Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1) = score;
+                Unsafe.Add(ref _intStart, offset) = doc;
+                Unsafe.Add(ref Unsafe.As<int, float>(ref _intStart), offset + 1) = score;
 
                 if (fields != null)
                 {
-                    ref IComparable[] fieldsRef = ref MemoryMarshal.GetArrayDataReference(_currentFields);
-                    Unsafe.Add(ref fieldsRef, _indexInSegment) = fields;
+                    Unsafe.Add(ref _fieldsStart, _indexInSegment) = fields;
                 }
 
                 _indexInSegment--;
@@ -339,8 +350,13 @@ public class ManagedScoreDocArray : IDisposable
             if (_segIndex < 0) ThrowWriterOutOfRange();
 
             var seg = _parent._segments[_segIndex];
-            _currentPacked = seg.PackedDocsAndScores;
-            _currentFields = seg.Fields;
+            _intStart = ref Unsafe.As<long, int>(ref MemoryMarshal.GetArrayDataReference(seg.PackedDocsAndScores));
+
+            if (seg.Fields != null)
+            {
+                _fieldsStart = ref MemoryMarshal.GetArrayDataReference(seg.Fields);
+            }
+
             _indexInSegment = seg.Capacity - 1;
 
             Write(doc, score, fields); // Recursively call Write to hit the fast path

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -9,7 +9,7 @@ namespace Lucene.Net.Util;
 
 public class ManagedScoreDocArray : IDisposable
 {
-    public static ManagedScoreDocArray Empty = new();
+    public static readonly ManagedScoreDocArray Empty = new();
 
     private const int SingleItemSize = sizeof(int);
     private const int MaxItemsPerSegment = 64 * 1024 / SingleItemSize; // 16,384 items - 64KB limit to avoid LOH
@@ -330,12 +330,6 @@ public class ManagedScoreDocArray : IDisposable
 
             // SLOW PATH: we crossed a boundary, switch to previous segment
             SwitchToPreviousSegment(doc, score, fields);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(int index, (int Doc, float Score, IComparable[] fields) fieldDoc)
-        {
-            Write(fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -320,7 +320,7 @@ public class ManagedScoreDocArray : IDisposable
             LongArrayPool.Return(seg.PackedDocsAndScores);
 
             if (seg.Fields != null)
-                FieldsArrayPool.Return(seg.Fields);
+                FieldsArrayPool.Return(seg.Fields, clearArray: true);
         }
 
         _segments.Clear();

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -108,15 +108,23 @@ public class ManagedScoreDocArray : IDisposable
     //   segIndex = Log2((globalIndex >> GrowthPhaseShift) + 1)
     private const int GrowthPhaseShift = 7;
 
-    public readonly List<Segment> _segments = new();
+    private readonly List<Segment> _segments = new();
 
     // Hot path caching - points to the packed long array
     private long[] _currentPacked;
-    public int _currentSegmentUsed;
+    private int _currentSegmentUsed;
     private int _currentSegmentCapacity;
 
     private int _length;
+
+    /// <summary>Gets the length of the array</summary>
     public int Length => _length;
+
+    /// <summary>Gets the number of allocated segments.</summary>
+    public int SegmentCount => _segments.Count;
+
+    /// <summary>Gets the segment capacity</summary>
+    public int SegmentCapacity(int num) => _segments[num].Capacity;
 
     public ManagedScoreDocArray()
     {

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -11,6 +11,9 @@ public class ManagedScoreDocArray : IDisposable
 {
     public static readonly ManagedScoreDocArray Empty = new();
 
+    public static ArrayPool<long> LongArrayPool = ArrayPool<long>.Shared;
+    public static ArrayPool<IComparable[]> FieldsArrayPool = ArrayPool<IComparable[]>.Shared;
+
     // size of a single packed item (int doc + float score) = 8 bytes
     private const int SingleItemSize = sizeof(long);
 
@@ -50,7 +53,7 @@ public class ManagedScoreDocArray : IDisposable
     {
     }
 
-    public ManagedScoreDocArray(int totalItems, bool hasFields)
+    public ManagedScoreDocArray(int totalItems, bool hasFields) : this()
     {
         _length = totalItems;
 
@@ -101,7 +104,7 @@ public class ManagedScoreDocArray : IDisposable
 
     private void AllocateSegment(int size, bool hasFields)
     {
-        var packed = ArrayPool<long>.Shared.Rent(size);
+        var packed = LongArrayPool.Rent(size);
 
         var segment = new Segment
         {
@@ -111,7 +114,7 @@ public class ManagedScoreDocArray : IDisposable
         };
 
         if (hasFields)
-            segment.Fields = ArrayPool<IComparable[]>.Shared.Rent(size);
+            segment.Fields = FieldsArrayPool.Rent(size);
 
         _segments.Add(segment);
     }
@@ -166,7 +169,7 @@ public class ManagedScoreDocArray : IDisposable
                 : Math.Min(_currentSegmentCapacity * 2, MaxItemsPerSegment);
         }
 
-        var packed = ArrayPool<long>.Shared.Rent(newSize);
+        var packed = LongArrayPool.Rent(newSize);
 
         var newSegment = new Segment
         {
@@ -237,10 +240,10 @@ public class ManagedScoreDocArray : IDisposable
 
         foreach (var seg in _segments)
         {
-            ArrayPool<long>.Shared.Return(seg.PackedDocsAndScores);
+            LongArrayPool.Return(seg.PackedDocsAndScores);
 
             if (seg.Fields != null)
-                ArrayPool<IComparable[]>.Shared.Return(seg.Fields);
+                FieldsArrayPool.Return(seg.Fields);
         }
 
         _segments.Clear();

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -52,18 +52,14 @@ public class ManagedScoreDocArray : IDisposable
 
     public ManagedScoreDocArray(int totalItems, bool fillFields)
     {
-        // 1. Initialize State
         _length = totalItems;
 
         if (fillFields)
             _fields = new IComparable[totalItems][];
 
         int remainingToAllocate = totalItems;
-        int currentSize = InitialItems; // 256
+        int currentSize = InitialItems;
 
-        // 2. Growth Phase Allocation (Small Segments)
-        // We allocate full segments (256, 512...) as long as we have items left
-        // and we haven't reached the 16k limit.
         while (_segments.Count < StablePhaseSegmentStartIndex && remainingToAllocate > 0)
         {
             AllocateSegment(currentSize);
@@ -71,11 +67,8 @@ public class ManagedScoreDocArray : IDisposable
             currentSize *= 2;
         }
 
-        // 3. Stable Phase Allocation (16k Segments)
         if (remainingToAllocate > 0)
         {
-            // Ceiling division: (remaining + 16383) / 16384
-            // Determines how many 16k blocks we need to cover the rest.
             int stableSegmentsNeeded = (remainingToAllocate + (MaxItemsPerSegment - 1)) >> MaxItemsLog2;
 
             for (int i = 0; i < stableSegmentsNeeded; i++)
@@ -84,38 +77,31 @@ public class ManagedScoreDocArray : IDisposable
             }
         }
 
-        // 4. CRITICAL: Sync "Hot Path" State
-        // We must point _currentDocs to the last segment and calculate exactly 
+        // we must point _currentDocs to the last segment and calculate exactly 
         // how many items are used in that last segment.
         if (_segments.Count > 0)
         {
             var lastIndex = _segments.Count - 1;
             var lastSeg = _segments[lastIndex];
 
-            // Set the pointers
             _currentDocs = lastSeg.Docs;
             _currentScores = lastSeg.Scores;
             _currentSegmentCapacity = lastSeg.Capacity;
 
-            // Calculate exact usage of the last segment.
-            // Logic: TotalItems - (Capacity of all previous segments)
             int itemsInPreviousSegments = 0;
             for (int i = 0; i < lastIndex; i++)
             {
                 itemsInPreviousSegments += _segments[i].Capacity;
             }
 
-            // Example: Total 20,000. Prev segments hold 16,128.
-            // _currentSegmentUsed = 3,872.
             _currentSegmentUsed = totalItems - itemsInPreviousSegments;
 
-            // Update the struct in the list so readers see the correct limit
+            // update the struct in the list so readers see the correct limit
             lastSeg.Used = _currentSegmentUsed;
-            _segments[lastIndex] = lastSeg;
         }
         else
         {
-            // Edge case: totalItems was 0
+            // totalItems was 0
             _currentDocs = null;
             _currentScores = null;
             _currentSegmentCapacity = 0;
@@ -133,7 +119,7 @@ public class ManagedScoreDocArray : IDisposable
             Docs = docs,
             Scores = scores,
             Capacity = size,
-            Used = size // Default to full, we fix the last one in the constructor
+            Used = size // default to full, we fix the last one in the constructor
         });
     }
 
@@ -144,8 +130,12 @@ public class ManagedScoreDocArray : IDisposable
             EnsureCapacity();
         }
 
-        _currentDocs[_currentSegmentUsed] = doc;
-        _currentScores[_currentSegmentUsed] = score;
+        // OPTIMIZATION: Unsafe ref arithmetic
+        ref int docsRef = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
+        ref float scoresRef = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+
+        Unsafe.Add(ref docsRef, _currentSegmentUsed) = doc;
+        Unsafe.Add(ref scoresRef, _currentSegmentUsed) = score;
 
         _currentSegmentUsed++;
         _length++;
@@ -161,7 +151,6 @@ public class ManagedScoreDocArray : IDisposable
             // and we modified the local field _currentSegmentUsed
             var lastSeg = _segments[^1];
             lastSeg.Used = _currentSegmentUsed;
-            _segments[^1] = lastSeg;
         }
 
         int newSize;
@@ -255,7 +244,7 @@ public class ManagedScoreDocArray : IDisposable
 
     private static void ThrowIndexOutOfRangeException() => throw new IndexOutOfRangeException();
 
-    public struct Segment
+    public class Segment
     {
         public int[] Docs;
         public float[] Scores;
@@ -275,11 +264,9 @@ public class ManagedScoreDocArray : IDisposable
     {
         private readonly ManagedScoreDocArray _parent;
 
-        // Cache the current segment arrays
         private int[] _currentDocs;
         private float[] _currentScores;
 
-        // State
         private int _segIndex;
         private int _indexInSegment;
 
@@ -290,10 +277,8 @@ public class ManagedScoreDocArray : IDisposable
             if (_parent.Length == 0)
                 return;
 
-            // Start at the last valid index
             int startIndex = parent._length - 1;
 
-            // 1. Calculate Initial Segment & Offset (Same math as Set/Get)
             if (startIndex >= GrowthPhaseTotalItems)
             {
                 int relativeIndex = startIndex - GrowthPhaseTotalItems;
@@ -307,7 +292,6 @@ public class ManagedScoreDocArray : IDisposable
                 _indexInSegment = startIndex - segmentStart;
             }
 
-            // 2. Load the arrays
             var seg = _parent._segments[_segIndex];
             _currentDocs = seg.Docs;
             _currentScores = seg.Scores;
@@ -319,24 +303,23 @@ public class ManagedScoreDocArray : IDisposable
             if (_parent.Length == 0)
                 ThrowOnEmptyArray();
 
-            // FAST PATH: We are still inside the current segment
-            // We use '>= 0' because we are moving backwards
+            // FAST PATH: we are still inside the current segment
+            // we use '>= 0' because we are moving backwards
             if (_indexInSegment >= 0)
             {
-                _currentDocs[_indexInSegment] = doc;
-                _currentScores[_indexInSegment] = score;
+                // OPTIMIZATION: Unsafe ref arithmetic
+                ref int docsRef = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
+                ref float scoresRef = ref MemoryMarshal.GetArrayDataReference(_currentScores);
 
-                _indexInSegment--; // Move backwards
+                Unsafe.Add(ref docsRef, _indexInSegment) = doc;
+                Unsafe.Add(ref scoresRef, _indexInSegment) = score;
+
+                _indexInSegment--;
                 return;
             }
 
-            // SLOW PATH: We crossed a boundary, switch to previous segment
+            // SLOW PATH: we crossed a boundary, switch to previous segment
             SwitchToPreviousSegment(doc, score);
-        }
-
-        private static void ThrowOnEmptyArray()
-        {
-            throw new InvalidOperationException("Cannot write to an empty array");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -350,26 +333,31 @@ public class ManagedScoreDocArray : IDisposable
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void SwitchToPreviousSegment(int doc, float score)
         {
-            // 1. Move to previous segment
             _segIndex--;
 
-            // Safety check (should not happen if loop logic is correct)
-            if (_segIndex < 0) throw new IndexOutOfRangeException("Writer went below index 0");
+            if (_segIndex < 0)
+                ThrowWriterOutOfRange();
 
             var seg = _parent._segments[_segIndex];
             _currentDocs = seg.Docs;
             _currentScores = seg.Scores;
 
-            // 2. Set index to the END of this new (previous) segment
-            // Note: We use 'Capacity' because Initialize() allocated the logical size.
-            // For growth segments, this finds the correct size (e.g., 8192 - 1).
             _indexInSegment = seg.Capacity - 1;
 
-            // 3. Perform the write
             _currentDocs[_indexInSegment] = doc;
             _currentScores[_indexInSegment] = score;
 
             _indexInSegment--;
+        }
+
+        private static void ThrowOnEmptyArray()
+        {
+            throw new InvalidOperationException("Cannot write to an empty array");
+        }
+
+        private static void ThrowWriterOutOfRange()
+        {
+            throw new IndexOutOfRangeException("Writer went below index 0");
         }
     }
 
@@ -380,25 +368,18 @@ public class ManagedScoreDocArray : IDisposable
 
     public struct ScoreDocReader
     {
-        // --- Managed Segments State ---
         private readonly ManagedScoreDocArray _managedParent;
         private int[] _currentDocs;
         private float[] _currentScores;
         private int _currentSegUsedCount;
 
-        // cursor State
         private int _segIndex;
         private int _indexInSegment;
 
-        // ---------------------------------------------------------
-        // CONSTRUCTOR: Managed Mode Only
-        // ---------------------------------------------------------
         public ScoreDocReader(ManagedScoreDocArray parent, int startIndex)
         {
             _managedParent = parent;
 
-            // 1. Calculate Initial Segment & Offset using Geometric Math
-            // (Reusing the O(1) math from the class constants)
             if (startIndex >= GrowthPhaseTotalItems)
             {
                 int relativeIndex = startIndex - GrowthPhaseTotalItems;
@@ -407,20 +388,17 @@ public class ManagedScoreDocArray : IDisposable
             }
             else
             {
-                // k = Log2(index/256 + 1)
                 _segIndex = BitOperations.Log2((uint)(startIndex >> GrowthPhaseShift) + 1);
                 int segmentStart = InitialItems * ((1 << _segIndex) - 1);
                 _indexInSegment = startIndex - segmentStart;
             }
 
-            // 2. Load the initial segment arrays
             if (_segIndex < parent._segments.Count)
             {
                 var seg = parent._segments[_segIndex];
                 _currentDocs = seg.Docs;
                 _currentScores = seg.Scores;
 
-                // Sync with the parent's "Hot Path" count if this is the active segment
                 _currentSegUsedCount = (_segIndex == parent._segments.Count - 1)
                     ? parent._currentSegmentUsed
                     : seg.Used;
@@ -439,15 +417,10 @@ public class ManagedScoreDocArray : IDisposable
             // FAST PATH: We are inside the boundaries of the current segment
             if (_indexInSegment < _currentSegUsedCount)
             {
-                // 1. Get a reference to the start of the array (Header)
-                // MemoryMarshal.GetArrayDataReference skips the check for index 0.
-                // It returns a 'ref int' to the first element.
+                // OPTIMIZATION: Unsafe ref arithmetic
                 ref int docsStart = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
                 ref float scoresStart = ref MemoryMarshal.GetArrayDataReference(_currentScores);
 
-                // 2. Perform Pointer Arithmetic (Managed)
-                // Unsafe.Add(ref start, offset) calculates address: start + (offset * sizeof(T))
-                // NO BOUNDS CHECK is performed.
                 doc = Unsafe.Add(ref docsStart, _indexInSegment);
                 score = Unsafe.Add(ref scoresStart, _indexInSegment);
 
@@ -455,18 +428,15 @@ public class ManagedScoreDocArray : IDisposable
                 return true;
             }
 
-            // SLOW PATH
             return ReadNextManagedSegment(out doc, out score);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private bool ReadNextManagedSegment(out int doc, out float score)
         {
-            // 1. Advance Segment Index
             _segIndex++;
             _indexInSegment = 0;
 
-            // 2. Check Bounds
             if (_managedParent == null || _segIndex >= _managedParent._segments.Count)
             {
                 doc = 0;
@@ -474,17 +444,14 @@ public class ManagedScoreDocArray : IDisposable
                 return false;
             }
 
-            // 3. Load New Segment Arrays
             var seg = _managedParent._segments[_segIndex];
             _currentDocs = seg.Docs;
             _currentScores = seg.Scores;
 
-            // 4. Sync Active Count
             _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1)
                 ? _managedParent._currentSegmentUsed
                 : seg.Used;
 
-            // 5. Retry Read (Double check in case next segment is empty, though unlikely)
             if (_indexInSegment < _currentSegUsedCount)
             {
                 doc = _currentDocs[_indexInSegment];

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -1,0 +1,501 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Lucene.Net.Util;
+
+public class ManagedScoreDocArray : IDisposable
+{
+    public static ManagedScoreDocArray Empty = new();
+
+    private const int SingleItemSize = sizeof(int);
+    private const int MaxItemsPerSegment = 64 * 1024 / SingleItemSize; // 16,384 items - 64KB limit to avoid LOH
+    private const int InitialItems = 1 * 1024 / SingleItemSize; // 256 items - 1KB
+
+    // math constants for the "Stable" phase
+    // log2(16384) = 14. we can use bit shifting instead of division.
+    private const int MaxItemsLog2 = 14;
+
+    // sequence: 256 -> 512 -> 1024 -> 2048 -> 4096 -> 8192
+    // the next one (16384) is the start of stable phase.
+    // sum = 256 + 512 + ... + 8192 = 16128 items.
+    private const int GrowthPhaseTotalItems = 16128;
+
+    // there are 6 segments in the growth phase (0 to 5)
+    // segment 6 is the first "Stable" (max Size) segment.
+    private const int StablePhaseSegmentStartIndex = 6;
+
+    // used to shift indexes for the Log2 calculation in the growth phase
+    private const int GrowthPhaseShift = 8;
+
+    public readonly List<Segment> _segments = new();
+
+    // hot path caching
+    private int[] _currentDocs;
+    private float[] _currentScores;
+    public int _currentSegmentUsed;
+    private int _currentSegmentCapacity;
+
+    private int _length;
+    private IComparable[][] _fields;
+
+    public int Length => _length;
+
+    public IComparable[][] Fields => _fields;
+
+    public ManagedScoreDocArray()
+    {
+    }
+
+    public ManagedScoreDocArray(int totalItems, bool fillFields)
+    {
+        // 1. Initialize State
+        _length = totalItems;
+
+        if (fillFields)
+            _fields = new IComparable[totalItems][];
+
+        int remainingToAllocate = totalItems;
+        int currentSize = InitialItems; // 256
+
+        // 2. Growth Phase Allocation (Small Segments)
+        // We allocate full segments (256, 512...) as long as we have items left
+        // and we haven't reached the 16k limit.
+        while (_segments.Count < StablePhaseSegmentStartIndex && remainingToAllocate > 0)
+        {
+            AllocateSegment(currentSize);
+            remainingToAllocate -= currentSize;
+            currentSize *= 2;
+        }
+
+        // 3. Stable Phase Allocation (16k Segments)
+        if (remainingToAllocate > 0)
+        {
+            // Ceiling division: (remaining + 16383) / 16384
+            // Determines how many 16k blocks we need to cover the rest.
+            int stableSegmentsNeeded = (remainingToAllocate + (MaxItemsPerSegment - 1)) >> MaxItemsLog2;
+
+            for (int i = 0; i < stableSegmentsNeeded; i++)
+            {
+                AllocateSegment(MaxItemsPerSegment);
+            }
+        }
+
+        // 4. CRITICAL: Sync "Hot Path" State
+        // We must point _currentDocs to the last segment and calculate exactly 
+        // how many items are used in that last segment.
+        if (_segments.Count > 0)
+        {
+            var lastIndex = _segments.Count - 1;
+            var lastSeg = _segments[lastIndex];
+
+            // Set the pointers
+            _currentDocs = lastSeg.Docs;
+            _currentScores = lastSeg.Scores;
+            _currentSegmentCapacity = lastSeg.Capacity;
+
+            // Calculate exact usage of the last segment.
+            // Logic: TotalItems - (Capacity of all previous segments)
+            int itemsInPreviousSegments = 0;
+            for (int i = 0; i < lastIndex; i++)
+            {
+                itemsInPreviousSegments += _segments[i].Capacity;
+            }
+
+            // Example: Total 20,000. Prev segments hold 16,128.
+            // _currentSegmentUsed = 3,872.
+            _currentSegmentUsed = totalItems - itemsInPreviousSegments;
+
+            // Update the struct in the list so readers see the correct limit
+            lastSeg.Used = _currentSegmentUsed;
+            _segments[lastIndex] = lastSeg;
+        }
+        else
+        {
+            // Edge case: totalItems was 0
+            _currentDocs = null;
+            _currentScores = null;
+            _currentSegmentCapacity = 0;
+            _currentSegmentUsed = 0;
+        }
+    }
+
+    private void AllocateSegment(int size)
+    {
+        var docs = ArrayPool<int>.Shared.Rent(size);
+        var scores = ArrayPool<float>.Shared.Rent(size);
+
+        _segments.Add(new Segment
+        {
+            Docs = docs,
+            Scores = scores,
+            Capacity = size,
+            Used = size // Default to full, we fix the last one in the constructor
+        });
+    }
+
+    public void Add(int doc, float score)
+    {
+        if (_currentSegmentUsed == _currentSegmentCapacity)
+        {
+            EnsureCapacity();
+        }
+
+        _currentDocs[_currentSegmentUsed] = doc;
+        _currentScores[_currentSegmentUsed] = score;
+
+        _currentSegmentUsed++;
+        _length++;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void EnsureCapacity()
+    {
+        if (_segments.Count > 0)
+        {
+            // if we have an active segment, update its 'Used' count before switching
+            // we have to copy the value type back into the list because Segment is a struct,
+            // and we modified the local field _currentSegmentUsed
+            var lastSeg = _segments[^1];
+            lastSeg.Used = _currentSegmentUsed;
+            _segments[^1] = lastSeg;
+        }
+
+        int newSize;
+        if (_segments.Count == 0)
+        {
+            newSize = InitialItems;
+        }
+        else
+        {
+            newSize = _currentSegmentCapacity == MaxItemsPerSegment
+                ? MaxItemsPerSegment
+                : Math.Min(_currentSegmentCapacity * 2, MaxItemsPerSegment);
+        }
+
+        var docs = ArrayPool<int>.Shared.Rent(newSize);
+        var scores = ArrayPool<float>.Shared.Rent(newSize);
+
+        var newSegment = new Segment
+        {
+            Docs = docs,
+            Scores = scores,
+            Used = 0,
+            Capacity = newSize
+        };
+
+        _segments.Add(newSegment);
+
+        // update hot-path cache
+        _currentDocs = docs;
+        _currentScores = scores;
+        _currentSegmentCapacity = newSize;
+        _currentSegmentUsed = 0;
+    }
+
+    public (int Doc, float Score) this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            if ((uint)index >= (uint)_length)
+                ThrowIndexOutOfRangeException();
+
+            // stable region (index >= 16128)
+            if (index >= GrowthPhaseTotalItems)
+            {
+                int relativeIndex = index - GrowthPhaseTotalItems;
+
+                int segmentOffset = relativeIndex >> MaxItemsLog2;
+                int indexInSegment = relativeIndex & (MaxItemsPerSegment - 1);
+
+                // offset by the number of growth segments (6 segments: 256..8192)
+                var seg = _segments[StablePhaseSegmentStartIndex + segmentOffset];
+                return (seg.Docs[indexInSegment], seg.Scores[indexInSegment]);
+            }
+
+            // growth region
+            return GetFromGrowthSegment(index);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private (int Doc, float Score) GetFromGrowthSegment(int index)
+    {
+        int segIndex = BitOperations.Log2((uint)(index >> GrowthPhaseShift) + 1);
+        int segmentStart = InitialItems * ((1 << segIndex) - 1);
+        int indexInSegment = index - segmentStart;
+        var seg = _segments[segIndex];
+        return (seg.Docs[indexInSegment], seg.Scores[indexInSegment]);
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        foreach (var seg in _segments)
+        {
+            ArrayPool<int>.Shared.Return(seg.Docs);
+            ArrayPool<float>.Shared.Return(seg.Scores);
+        }
+
+        _segments.Clear();
+        _currentDocs = null;
+        _currentScores = null;
+        _length = _currentSegmentUsed = _currentSegmentCapacity = 0;
+    }
+
+    ~ManagedScoreDocArray()
+    {
+        Dispose();
+    }
+
+    private static void ThrowIndexOutOfRangeException() => throw new IndexOutOfRangeException();
+
+    public struct Segment
+    {
+        public int[] Docs;
+        public float[] Scores;
+        public int Used;
+        public int Capacity;
+    }
+
+    /// <summary>
+    /// Returns a writer optimized for filling the array backwards from (length - 1) down to 0.
+    /// </summary>
+    public BackwardsWriter GetBackwardsWriter()
+    {
+        return new BackwardsWriter(this);
+    }
+
+    public struct BackwardsWriter
+    {
+        private readonly ManagedScoreDocArray _parent;
+
+        // Cache the current segment arrays
+        private int[] _currentDocs;
+        private float[] _currentScores;
+
+        // State
+        private int _segIndex;
+        private int _indexInSegment;
+
+        public BackwardsWriter(ManagedScoreDocArray parent)
+        {
+            _parent = parent;
+
+            if (_parent.Length == 0)
+                return;
+
+            // Start at the last valid index
+            int startIndex = parent._length - 1;
+
+            // 1. Calculate Initial Segment & Offset (Same math as Set/Get)
+            if (startIndex >= GrowthPhaseTotalItems)
+            {
+                int relativeIndex = startIndex - GrowthPhaseTotalItems;
+                _segIndex = StablePhaseSegmentStartIndex + (relativeIndex >> MaxItemsLog2);
+                _indexInSegment = relativeIndex & (MaxItemsPerSegment - 1);
+            }
+            else
+            {
+                _segIndex = BitOperations.Log2((uint)(startIndex >> GrowthPhaseShift) + 1);
+                int segmentStart = InitialItems * ((1 << _segIndex) - 1);
+                _indexInSegment = startIndex - segmentStart;
+            }
+
+            // 2. Load the arrays
+            var seg = _parent._segments[_segIndex];
+            _currentDocs = seg.Docs;
+            _currentScores = seg.Scores;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(int doc, float score)
+        {
+            if (_parent.Length == 0)
+                ThrowOnEmptyArray();
+
+            // FAST PATH: We are still inside the current segment
+            // We use '>= 0' because we are moving backwards
+            if (_indexInSegment >= 0)
+            {
+                _currentDocs[_indexInSegment] = doc;
+                _currentScores[_indexInSegment] = score;
+
+                _indexInSegment--; // Move backwards
+                return;
+            }
+
+            // SLOW PATH: We crossed a boundary, switch to previous segment
+            SwitchToPreviousSegment(doc, score);
+        }
+
+        private static void ThrowOnEmptyArray()
+        {
+            throw new InvalidOperationException("Cannot write to an empty array");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(int index, (int Doc, float Score, IComparable[] fields) fieldDoc)
+        {
+            Write(fieldDoc.Doc, fieldDoc.Score);
+
+            _parent._fields[index] = fieldDoc.fields;
+    }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SwitchToPreviousSegment(int doc, float score)
+        {
+            // 1. Move to previous segment
+            _segIndex--;
+
+            // Safety check (should not happen if loop logic is correct)
+            if (_segIndex < 0) throw new IndexOutOfRangeException("Writer went below index 0");
+
+            var seg = _parent._segments[_segIndex];
+            _currentDocs = seg.Docs;
+            _currentScores = seg.Scores;
+
+            // 2. Set index to the END of this new (previous) segment
+            // Note: We use 'Capacity' because Initialize() allocated the logical size.
+            // For growth segments, this finds the correct size (e.g., 8192 - 1).
+            _indexInSegment = seg.Capacity - 1;
+
+            // 3. Perform the write
+            _currentDocs[_indexInSegment] = doc;
+            _currentScores[_indexInSegment] = score;
+
+            _indexInSegment--;
+        }
+    }
+
+    public ScoreDocReader GetReader(int start)
+    {
+        return new ScoreDocReader(this, start);
+    }
+
+    public struct ScoreDocReader
+    {
+        // --- Managed Segments State ---
+        private readonly ManagedScoreDocArray _managedParent;
+        private int[] _currentDocs;
+        private float[] _currentScores;
+        private int _currentSegUsedCount;
+
+        // cursor State
+        private int _segIndex;
+        private int _indexInSegment;
+
+        // ---------------------------------------------------------
+        // CONSTRUCTOR: Managed Mode Only
+        // ---------------------------------------------------------
+        public ScoreDocReader(ManagedScoreDocArray parent, int startIndex)
+        {
+            _managedParent = parent;
+
+            // 1. Calculate Initial Segment & Offset using Geometric Math
+            // (Reusing the O(1) math from the class constants)
+            if (startIndex >= GrowthPhaseTotalItems)
+            {
+                int relativeIndex = startIndex - GrowthPhaseTotalItems;
+                _segIndex = StablePhaseSegmentStartIndex + (relativeIndex >> MaxItemsLog2);
+                _indexInSegment = relativeIndex & (MaxItemsPerSegment - 1);
+            }
+            else
+            {
+                // k = Log2(index/256 + 1)
+                _segIndex = BitOperations.Log2((uint)(startIndex >> GrowthPhaseShift) + 1);
+                int segmentStart = InitialItems * ((1 << _segIndex) - 1);
+                _indexInSegment = startIndex - segmentStart;
+            }
+
+            // 2. Load the initial segment arrays
+            if (_segIndex < parent._segments.Count)
+            {
+                var seg = parent._segments[_segIndex];
+                _currentDocs = seg.Docs;
+                _currentScores = seg.Scores;
+
+                // Sync with the parent's "Hot Path" count if this is the active segment
+                _currentSegUsedCount = (_segIndex == parent._segments.Count - 1)
+                    ? parent._currentSegmentUsed
+                    : seg.Used;
+            }
+            else
+            {
+                _currentDocs = null;
+                _currentScores = null;
+                _currentSegUsedCount = 0;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Read(out int doc, out float score)
+        {
+            // FAST PATH: We are inside the boundaries of the current segment
+            if (_indexInSegment < _currentSegUsedCount)
+            {
+                // 1. Get a reference to the start of the array (Header)
+                // MemoryMarshal.GetArrayDataReference skips the check for index 0.
+                // It returns a 'ref int' to the first element.
+                ref int docsStart = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
+                ref float scoresStart = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+
+                // 2. Perform Pointer Arithmetic (Managed)
+                // Unsafe.Add(ref start, offset) calculates address: start + (offset * sizeof(T))
+                // NO BOUNDS CHECK is performed.
+                doc = Unsafe.Add(ref docsStart, _indexInSegment);
+                score = Unsafe.Add(ref scoresStart, _indexInSegment);
+
+                _indexInSegment++;
+                return true;
+            }
+
+            // SLOW PATH
+            return ReadNextManagedSegment(out doc, out score);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool ReadNextManagedSegment(out int doc, out float score)
+        {
+            // 1. Advance Segment Index
+            _segIndex++;
+            _indexInSegment = 0;
+
+            // 2. Check Bounds
+            if (_managedParent == null || _segIndex >= _managedParent._segments.Count)
+            {
+                doc = 0;
+                score = 0;
+                return false;
+            }
+
+            // 3. Load New Segment Arrays
+            var seg = _managedParent._segments[_segIndex];
+            _currentDocs = seg.Docs;
+            _currentScores = seg.Scores;
+
+            // 4. Sync Active Count
+            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1)
+                ? _managedParent._currentSegmentUsed
+                : seg.Used;
+
+            // 5. Retry Read (Double check in case next segment is empty, though unlikely)
+            if (_indexInSegment < _currentSegUsedCount)
+            {
+                doc = _currentDocs[_indexInSegment];
+                score = _currentScores[_indexInSegment];
+                _indexInSegment++;
+                return true;
+            }
+
+            doc = 0;
+            score = 0;
+            return false;
+        }
+    }
+}

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -83,6 +84,9 @@ public class ManagedScoreDocArray : IDisposable
     public static ArrayPool<long> LongArrayPool = ArrayPool<long>.Shared;
     public static ArrayPool<IComparable[]> FieldsArrayPool = ArrayPool<IComparable[]>.Shared;
 
+    private ArrayPool<long> _longArrayPool;
+    private ArrayPool<IComparable[]> _fieldsArrayPool;
+
     // Each packed item is one long: int doc (4 bytes) + float score (4 bytes) = 8 bytes.
     private const int SingleItemSize = sizeof(long);
 
@@ -126,8 +130,10 @@ public class ManagedScoreDocArray : IDisposable
     /// <summary>Gets the segment capacity</summary>
     public int SegmentCapacity(int num) => _segments[num].Capacity;
 
-    public ManagedScoreDocArray()
+    public ManagedScoreDocArray(ArrayPool<long> longArrayPool = null, ArrayPool<IComparable[]> fieldsArrayPool = null)
     {
+        _longArrayPool = longArrayPool ?? LongArrayPool;
+        _fieldsArrayPool = fieldsArrayPool ?? FieldsArrayPool;
     }
 
     public ManagedScoreDocArray(int totalItems, bool hasFields) : this()
@@ -181,7 +187,7 @@ public class ManagedScoreDocArray : IDisposable
 
     private void AllocateSegment(int size, bool hasFields)
     {
-        var packed = LongArrayPool.Rent(size);
+        var packed = _longArrayPool.Rent(size);
 
         var segment = new Segment
         {
@@ -191,7 +197,7 @@ public class ManagedScoreDocArray : IDisposable
         };
 
         if (hasFields)
-            segment.Fields = FieldsArrayPool.Rent(size);
+            segment.Fields = _fieldsArrayPool.Rent(size);
 
         _segments.Add(segment);
     }
@@ -246,7 +252,7 @@ public class ManagedScoreDocArray : IDisposable
                 : Math.Min(_currentSegmentCapacity * 2, MaxItemsPerSegment);
         }
 
-        var packed = LongArrayPool.Rent(newSize);
+        var packed = _longArrayPool.Rent(newSize);
 
         var newSegment = new Segment
         {
@@ -317,10 +323,10 @@ public class ManagedScoreDocArray : IDisposable
 
         foreach (var seg in _segments)
         {
-            LongArrayPool.Return(seg.PackedDocsAndScores);
+            _longArrayPool.Return(seg.PackedDocsAndScores);
 
             if (seg.Fields != null)
-                FieldsArrayPool.Return(seg.Fields, clearArray: true);
+                _fieldsArrayPool.Return(seg.Fields, clearArray: true);
         }
 
         _segments.Clear();
@@ -439,7 +445,10 @@ public class ManagedScoreDocArray : IDisposable
             Write(doc, score, fields); // Recursively call Write to hit the fast path
         }
 
+        [DoesNotReturn]
         private static void ThrowOnEmptyArray() => throw new InvalidOperationException("Cannot write to an empty array");
+        
+        [DoesNotReturn]
         private static void ThrowWriterOutOfRange() => throw new IndexOutOfRangeException("Writer went below index 0");
     }
 

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -11,31 +11,35 @@ public class ManagedScoreDocArray : IDisposable
 {
     public static readonly ManagedScoreDocArray Empty = new();
 
-    private const int SingleItemSize = sizeof(int);
-    private const int MaxItemsPerSegment = 64 * 1024 / SingleItemSize; // 16,384 items - 64KB limit to avoid LOH
-    private const int InitialItems = 1 * 1024 / SingleItemSize; // 256 items - 1KB
+    // size of a single packed item (int doc + float score) = 8 bytes
+    private const int SingleItemSize = sizeof(long);
 
-    // math constants for the "Stable" phase
-    // log2(16384) = 14. we can use bit shifting instead of division.
-    private const int MaxItemsLog2 = 14;
+    // 8,192 items * 8 bytes = 64KB. 
+    // we keep a single array under the 85KB LOH threshold.
+    private const int MaxItemsPerSegment = 64 * 1024 / SingleItemSize;
 
-    // sequence: 256 -> 512 -> 1024 -> 2048 -> 4096 -> 8192
-    // the next one (16384) is the start of stable phase.
-    // sum = 256 + 512 + ... + 8192 = 16128 items.
-    private const int GrowthPhaseTotalItems = 16128;
+    // 128 items * 8 bytes = 1KB
+    private const int InitialItems = 1 * 1024 / SingleItemSize;
 
-    // there are 6 segments in the growth phase (0 to 5)
-    // segment 6 is the first "Stable" (max Size) segment.
+    // Log2(8192) = 13
+    private const int MaxItemsLog2 = 13;
+
+    // Sequence: 128 -> 256 -> 512 -> 1024 -> 2048 -> 4096
+    // The next one (8192) is the start of stable phase.
+    // Sum = 128 + 256 + ... + 4096 = 8064 items.
+    private const int GrowthPhaseTotalItems = 8064;
+
+    // There are 6 segments in the growth phase (0 to 5)
+    // Segment 6 is the first "Stable" (max Size) segment.
     private const int StablePhaseSegmentStartIndex = 6;
 
-    // used to shift indexes for the Log2 calculation in the growth phase
-    private const int GrowthPhaseShift = 8;
+    // Log2(128) = 7. Used for shifting in growth phase.
+    private const int GrowthPhaseShift = 7;
 
     public readonly List<Segment> _segments = new();
 
-    // hot path caching
-    private int[] _currentDocs;
-    private float[] _currentScores;
+    // Hot path caching - points to the packed long array
+    private long[] _currentPacked;
     public int _currentSegmentUsed;
     private int _currentSegmentCapacity;
 
@@ -70,15 +74,12 @@ public class ManagedScoreDocArray : IDisposable
             }
         }
 
-        // we must point _currentDocs to the last segment and calculate exactly 
-        // how many items are used in that last segment.
         if (_segments.Count > 0)
         {
             var lastIndex = _segments.Count - 1;
             var lastSeg = _segments[lastIndex];
 
-            _currentDocs = lastSeg.Docs;
-            _currentScores = lastSeg.Scores;
+            _currentPacked = lastSeg.PackedDocsAndScores;
             _currentSegmentCapacity = lastSeg.Capacity;
 
             int itemsInPreviousSegments = 0;
@@ -88,15 +89,11 @@ public class ManagedScoreDocArray : IDisposable
             }
 
             _currentSegmentUsed = totalItems - itemsInPreviousSegments;
-
-            // update the struct in the list so readers see the correct limit
             lastSeg.Used = _currentSegmentUsed;
         }
         else
         {
-            // totalItems was 0
-            _currentDocs = null;
-            _currentScores = null;
+            _currentPacked = null;
             _currentSegmentCapacity = 0;
             _currentSegmentUsed = 0;
         }
@@ -104,15 +101,13 @@ public class ManagedScoreDocArray : IDisposable
 
     private void AllocateSegment(int size, bool hasFields)
     {
-        var docs = ArrayPool<int>.Shared.Rent(size);
-        var scores = ArrayPool<float>.Shared.Rent(size);
+        var packed = ArrayPool<long>.Shared.Rent(size);
 
         var segment = new Segment
         {
-            Docs = docs,
-            Scores = scores,
+            PackedDocsAndScores = packed,
             Capacity = size,
-            Used = size // default to full, we fix the last one in the constructor
+            Used = size
         };
 
         if (hasFields)
@@ -121,6 +116,7 @@ public class ManagedScoreDocArray : IDisposable
         _segments.Add(segment);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Add(int doc, float score)
     {
         if (_currentSegmentUsed == _currentSegmentCapacity)
@@ -128,12 +124,22 @@ public class ManagedScoreDocArray : IDisposable
             EnsureCapacity();
         }
 
-        // OPTIMIZATION: Unsafe ref arithmetic
-        ref int docsRef = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
-        ref float scoresRef = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+        // OPTIMIZATION: Ref aliasing
+        // 1. Get reference to the start of the long[] array
+        ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
 
-        Unsafe.Add(ref docsRef, _currentSegmentUsed) = doc;
-        Unsafe.Add(ref scoresRef, _currentSegmentUsed) = score;
+        // 2. Reinterpret that memory as int[]
+        ref int intStart = ref Unsafe.As<long, int>(ref longStart);
+
+        // 3. Calculate offset: each "Item" is 2 ints long (8 bytes)
+        //    Offset for Doc = index * 2
+        //    Offset for Score = index * 2 + 1
+        int offset = _currentSegmentUsed * 2;
+
+        Unsafe.Add(ref intStart, offset) = doc;
+
+        // 4. Reinterpret the specific slot for score as float and write
+        Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1) = score;
 
         _currentSegmentUsed++;
         _length++;
@@ -144,9 +150,6 @@ public class ManagedScoreDocArray : IDisposable
     {
         if (_segments.Count > 0)
         {
-            // if we have an active segment, update its 'Used' count before switching
-            // we have to copy the value type back into the list because Segment is a struct,
-            // and we modified the local field _currentSegmentUsed
             var lastSeg = _segments[^1];
             lastSeg.Used = _currentSegmentUsed;
         }
@@ -163,22 +166,18 @@ public class ManagedScoreDocArray : IDisposable
                 : Math.Min(_currentSegmentCapacity * 2, MaxItemsPerSegment);
         }
 
-        var docs = ArrayPool<int>.Shared.Rent(newSize);
-        var scores = ArrayPool<float>.Shared.Rent(newSize);
+        var packed = ArrayPool<long>.Shared.Rent(newSize);
 
         var newSegment = new Segment
         {
-            Docs = docs,
-            Scores = scores,
+            PackedDocsAndScores = packed,
             Used = 0,
             Capacity = newSize
         };
 
         _segments.Add(newSegment);
 
-        // update hot-path cache
-        _currentDocs = docs;
-        _currentScores = scores;
+        _currentPacked = packed;
         _currentSegmentCapacity = newSize;
         _currentSegmentUsed = 0;
     }
@@ -191,20 +190,16 @@ public class ManagedScoreDocArray : IDisposable
             if ((uint)index >= (uint)_length)
                 ThrowIndexOutOfRangeException();
 
-            // stable region (index >= 16128)
             if (index >= GrowthPhaseTotalItems)
             {
                 int relativeIndex = index - GrowthPhaseTotalItems;
-
                 int segmentOffset = relativeIndex >> MaxItemsLog2;
                 int indexInSegment = relativeIndex & (MaxItemsPerSegment - 1);
 
-                // offset by the number of growth segments (6 segments: 256..8192)
                 var seg = _segments[StablePhaseSegmentStartIndex + segmentOffset];
-                return (seg.Docs[indexInSegment], seg.Scores[indexInSegment]);
+                return GetPackedValue(seg.PackedDocsAndScores, indexInSegment);
             }
 
-            // growth region
             return GetFromGrowthSegment(index);
         }
     }
@@ -216,7 +211,20 @@ public class ManagedScoreDocArray : IDisposable
         int segmentStart = InitialItems * ((1 << segIndex) - 1);
         int indexInSegment = index - segmentStart;
         var seg = _segments[segIndex];
-        return (seg.Docs[indexInSegment], seg.Scores[indexInSegment]);
+        return GetPackedValue(seg.PackedDocsAndScores, indexInSegment);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static (int, float) GetPackedValue(long[] packed, int index)
+    {
+        ref long longStart = ref MemoryMarshal.GetArrayDataReference(packed);
+        ref int intStart = ref Unsafe.As<long, int>(ref longStart);
+        int offset = index * 2;
+
+        int doc = Unsafe.Add(ref intStart, offset);
+        float score = Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1);
+
+        return (doc, score);
     }
 
     public void Dispose()
@@ -225,16 +233,14 @@ public class ManagedScoreDocArray : IDisposable
 
         foreach (var seg in _segments)
         {
-            ArrayPool<int>.Shared.Return(seg.Docs);
-            ArrayPool<float>.Shared.Return(seg.Scores);
+            ArrayPool<long>.Shared.Return(seg.PackedDocsAndScores);
 
             if (seg.Fields != null)
                 ArrayPool<IComparable[]>.Shared.Return(seg.Fields);
         }
 
         _segments.Clear();
-        _currentDocs = null;
-        _currentScores = null;
+        _currentPacked = null;
         _length = _currentSegmentUsed = _currentSegmentCapacity = 0;
     }
 
@@ -247,27 +253,18 @@ public class ManagedScoreDocArray : IDisposable
 
     public class Segment
     {
-        public int[] Docs;
-        public float[] Scores;
+        public long[] PackedDocsAndScores;
         public IComparable[][] Fields;
         public int Used;
         public int Capacity;
     }
 
-    /// <summary>
-    /// Returns a writer optimized for filling the array backwards from (length - 1) down to 0.
-    /// </summary>
-    public BackwardsWriter GetBackwardsWriter()
-    {
-        return new BackwardsWriter(this);
-    }
+    public BackwardsWriter GetBackwardsWriter() => new(this);
 
     public struct BackwardsWriter
     {
         private readonly ManagedScoreDocArray _parent;
-
-        private int[] _currentDocs;
-        private float[] _currentScores;
+        private long[] _currentPacked;
         private IComparable[][] _currentFields;
 
         private int _segIndex;
@@ -296,8 +293,7 @@ public class ManagedScoreDocArray : IDisposable
             }
 
             var seg = _parent._segments[_segIndex];
-            _currentDocs = seg.Docs;
-            _currentScores = seg.Scores;
+            _currentPacked = seg.PackedDocsAndScores;
             _currentFields = seg.Fields;
         }
 
@@ -307,16 +303,14 @@ public class ManagedScoreDocArray : IDisposable
             if (_parent.Length == 0)
                 ThrowOnEmptyArray();
 
-            // FAST PATH: we are still inside the current segment
-            // we use '>= 0' because we are moving backwards
             if (_indexInSegment >= 0)
             {
-                // OPTIMIZATION: Unsafe ref arithmetic
-                ref int docsRef = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
-                ref float scoresRef = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
+                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
 
-                Unsafe.Add(ref docsRef, _indexInSegment) = doc;
-                Unsafe.Add(ref scoresRef, _indexInSegment) = score;
+                int offset = _indexInSegment * 2;
+                Unsafe.Add(ref intStart, offset) = doc;
+                Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1) = score;
 
                 if (fields != null)
                 {
@@ -328,7 +322,6 @@ public class ManagedScoreDocArray : IDisposable
                 return;
             }
 
-            // SLOW PATH: we crossed a boundary, switch to previous segment
             SwitchToPreviousSegment(doc, score, fields);
         }
 
@@ -336,47 +329,26 @@ public class ManagedScoreDocArray : IDisposable
         private void SwitchToPreviousSegment(int doc, float score, IComparable[] fields = null)
         {
             _segIndex--;
-
-            if (_segIndex < 0)
-                ThrowWriterOutOfRange();
+            if (_segIndex < 0) ThrowWriterOutOfRange();
 
             var seg = _parent._segments[_segIndex];
-            _currentDocs = seg.Docs;
-            _currentScores = seg.Scores;
+            _currentPacked = seg.PackedDocsAndScores;
             _currentFields = seg.Fields;
-
             _indexInSegment = seg.Capacity - 1;
 
-            _currentDocs[_indexInSegment] = doc;
-            _currentScores[_indexInSegment] = score;
-
-            if (fields != null)
-                _currentFields[_indexInSegment] = fields;
-
-            _indexInSegment--;
+            Write(doc, score, fields); // Recursively call Write to hit the fast path
         }
 
-        private static void ThrowOnEmptyArray()
-        {
-            throw new InvalidOperationException("Cannot write to an empty array");
-        }
-
-        private static void ThrowWriterOutOfRange()
-        {
-            throw new IndexOutOfRangeException("Writer went below index 0");
-        }
+        private static void ThrowOnEmptyArray() => throw new InvalidOperationException("Cannot write to an empty array");
+        private static void ThrowWriterOutOfRange() => throw new IndexOutOfRangeException("Writer went below index 0");
     }
 
-    public ScoreDocReader GetReader(int start)
-    {
-        return new ScoreDocReader(this, start);
-    }
+    public ScoreDocReader GetReader(int start) => new(this, start);
 
     public struct ScoreDocReader
     {
         private readonly ManagedScoreDocArray _managedParent;
-        private int[] _currentDocs;
-        private float[] _currentScores;
+        private long[] _currentPacked;
         private IComparable[][] _currentFields;
         private int _currentSegUsedCount;
 
@@ -403,18 +375,13 @@ public class ManagedScoreDocArray : IDisposable
             if (_segIndex < parent._segments.Count)
             {
                 var seg = parent._segments[_segIndex];
-                _currentDocs = seg.Docs;
-                _currentScores = seg.Scores;
+                _currentPacked = seg.PackedDocsAndScores;
                 _currentFields = seg.Fields;
-
-                _currentSegUsedCount = (_segIndex == parent._segments.Count - 1)
-                    ? parent._currentSegmentUsed
-                    : seg.Used;
+                _currentSegUsedCount = (_segIndex == parent._segments.Count - 1) ? parent._currentSegmentUsed : seg.Used;
             }
             else
             {
-                _currentDocs = null;
-                _currentScores = null;
+                _currentPacked = null;
                 _currentFields = null;
                 _currentSegUsedCount = 0;
             }
@@ -423,15 +390,14 @@ public class ManagedScoreDocArray : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Read(out int doc, out float score)
         {
-            // FAST PATH: We are inside the boundaries of the current segment
             if (_indexInSegment < _currentSegUsedCount)
             {
-                // OPTIMIZATION: Unsafe ref arithmetic
-                ref int docsStart = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
-                ref float scoresStart = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
+                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
+                int offset = _indexInSegment * 2;
 
-                doc = Unsafe.Add(ref docsStart, _indexInSegment);
-                score = Unsafe.Add(ref scoresStart, _indexInSegment);
+                doc = Unsafe.Add(ref intStart, offset);
+                score = Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1);
 
                 _indexInSegment++;
                 return true;
@@ -454,17 +420,18 @@ public class ManagedScoreDocArray : IDisposable
             }
 
             var seg = _managedParent._segments[_segIndex];
-            _currentDocs = seg.Docs;
-            _currentScores = seg.Scores;
-
-            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1)
-                ? _managedParent._currentSegmentUsed
-                : seg.Used;
+            _currentPacked = seg.PackedDocsAndScores;
+            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1) ? _managedParent._currentSegmentUsed : seg.Used;
 
             if (_indexInSegment < _currentSegUsedCount)
             {
-                doc = _currentDocs[_indexInSegment];
-                score = _currentScores[_indexInSegment];
+                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
+                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
+                int offset = _indexInSegment * 2;
+
+                doc = Unsafe.Add(ref intStart, offset);
+                score = Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1);
+
                 _indexInSegment++;
                 return true;
             }
@@ -477,22 +444,22 @@ public class ManagedScoreDocArray : IDisposable
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Read(out int doc, out float score, out IComparable[] fields)
         {
-            // FAST PATH: We are inside the boundaries of the current segment
+            // Fast path logic duplicated to allow inlining of the "with fields" variant
             if (_indexInSegment < _currentSegUsedCount)
             {
-                // OPTIMIZATION: Unsafe ref arithmetic
-                ref int docsStart = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
-                ref float scoresStart = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
+                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
                 ref IComparable[] fieldsStart = ref MemoryMarshal.GetArrayDataReference(_currentFields);
 
-                doc = Unsafe.Add(ref docsStart, _indexInSegment);
-                score = Unsafe.Add(ref scoresStart, _indexInSegment);
+                int offset = _indexInSegment * 2;
+
+                doc = Unsafe.Add(ref intStart, offset);
+                score = Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1);
                 fields = Unsafe.Add(ref fieldsStart, _indexInSegment);
 
                 _indexInSegment++;
                 return true;
             }
-
             return ReadNextManagedSegment(out doc, out score, out fields);
         }
 
@@ -511,19 +478,20 @@ public class ManagedScoreDocArray : IDisposable
             }
 
             var seg = _managedParent._segments[_segIndex];
-            _currentDocs = seg.Docs;
-            _currentScores = seg.Scores;
+            _currentPacked = seg.PackedDocsAndScores;
             _currentFields = seg.Fields;
-
-            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1)
-                ? _managedParent._currentSegmentUsed
-                : seg.Used;
+            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1) ? _managedParent._currentSegmentUsed : seg.Used;
 
             if (_indexInSegment < _currentSegUsedCount)
             {
-                doc = _currentDocs[_indexInSegment];
-                score = _currentScores[_indexInSegment];
+                ref long longStart = ref MemoryMarshal.GetArrayDataReference(_currentPacked);
+                ref int intStart = ref Unsafe.As<long, int>(ref longStart);
+
+                int offset = _indexInSegment * 2;
+                doc = Unsafe.Add(ref intStart, offset);
+                score = Unsafe.Add(ref Unsafe.As<int, float>(ref intStart), offset + 1);
                 fields = _currentFields[_indexInSegment];
+
                 _indexInSegment++;
                 return true;
             }

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -356,7 +356,6 @@ public class ManagedScoreDocArray : IDisposable
         private readonly ManagedScoreDocArray _parent;
         private ref int _intStart;
         private ref IComparable[] _fieldsStart;
-        private bool _hasFields;
 
         private int _segIndex;
         private int _indexInSegment;
@@ -364,7 +363,6 @@ public class ManagedScoreDocArray : IDisposable
         public BackwardsWriter(ManagedScoreDocArray parent)
         {
             _parent = parent;
-            _hasFields = false;
 
             if (_parent.Length == 0)
             {
@@ -394,7 +392,6 @@ public class ManagedScoreDocArray : IDisposable
             if (seg.Fields != null)
             {
                 _fieldsStart = ref MemoryMarshal.GetArrayDataReference(seg.Fields);
-                _hasFields = true;
             }
             else
             {

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -7,6 +7,75 @@ using System.Runtime.InteropServices;
 
 namespace Lucene.Net.Util;
 
+// =========================================================================
+// SEGMENT ARCHITECTURE — Two-Phase Segmented Array
+// =========================================================================
+//
+// This data structure stores packed (doc, score) pairs as long values in a
+// segmented array. Each item is 8 bytes: 4 bytes for doc (int) + 4 bytes for
+// score (float), packed into a single long via Unsafe reinterpretation.
+//
+// The array is split into segments to avoid Large Object Heap (LOH) allocations.
+// Any single array >= 85,000 bytes goes on the LOH, causing GC pressure.
+// We cap each segment at 64KB (8,192 items × 8 bytes), staying well under.
+//
+// Two growth phases ensure both small and large collections are efficient:
+//
+// ── PHASE 1: Growth Phase (Segments 0–5) ──────────────────────────────────
+//
+// Segment sizes double each time, starting from InitialItems (128):
+//
+//   Seg Index │ Capacity │ Bytes  │ Cumulative Items │ Global Index Range
+//   ──────────┼──────────┼────────┼──────────────────┼────────────────────
+//       0     │    128   │   1 KB │        128       │ [0 .. 127]
+//       1     │    256   │   2 KB │        384       │ [128 .. 383]
+//       2     │    512   │   4 KB │        896       │ [384 .. 895]
+//       3     │  1,024   │   8 KB │      1,920       │ [896 .. 1,919]
+//       4     │  2,048   │  16 KB │      3,968       │ [1,920 .. 3,967]
+//       5     │  4,096   │  32 KB │      8,064       │ [3,968 .. 8,063]
+//             │          │        │                  │
+//             │  Total:  │  63 KB │  8,064 items     │
+//
+// This doubling strategy means small result sets (common case: top-10, top-100)
+// waste minimal memory, while still scaling up quickly.
+//
+// O(1) random access in the growth phase uses bit tricks:
+//   segIndex     = Log2((globalIndex >> 7) + 1)
+//   segmentStart = 128 * ((1 << segIndex) - 1)       // geometric sum
+//   localIndex   = globalIndex - segmentStart
+//
+// ── PHASE 2: Stable Phase (Segments 6+) ───────────────────────────────────
+//
+// Once the growth phase is exhausted (after 8,064 items), all subsequent
+// segments are fixed at MaxItemsPerSegment (8,192 items = 64KB each).
+//
+//   Seg Index │ Capacity │ Bytes  │ Cumulative Items │ Global Index Range
+//   ──────────┼──────────┼────────┼──────────────────┼────────────────────
+//       6     │  8,192   │  64 KB │     16,256       │ [8,064 .. 16,255]
+//       7     │  8,192   │  64 KB │     24,448       │ [16,256 .. 24,447]
+//       8     │  8,192   │  64 KB │     32,640       │ [24,448 .. 32,639]
+//      ...    │   ...    │  ...   │       ...        │       ...
+//
+// O(1) random access in the stable phase is simple division/modulo via shifts:
+//   relativeIndex = globalIndex - GrowthPhaseTotalItems (8,064)
+//   segIndex      = StablePhaseSegmentStartIndex + (relativeIndex >> 13)
+//   localIndex    = relativeIndex & (8,191)             // mask = 8192-1
+//
+// ── WHY NOT JUST USE ONE BIG ARRAY? ───────────────────────────────────────
+//
+// A single array for 128K items = 1MB → LOH → Gen2 GC pressure.
+// With segments: max 64KB per array → always SOH → collected cheaply in Gen0/1.
+// Arrays are rented from ArrayPool, so repeated searches reuse buffers.
+//
+// ── MEMORY LAYOUT PER ITEM ────────────────────────────────────────────────
+//
+//   long[i] = | int doc (4 bytes) | float score (4 bytes) |
+//
+// Accessed via Unsafe.As reinterpretation: the long[] is treated as an int[]
+// of twice the length. Item N is at int offset N*2 (doc) and N*2+1 (score).
+//
+// =========================================================================
+
 public class ManagedScoreDocArray : IDisposable
 {
     public static readonly ManagedScoreDocArray Empty = new();
@@ -14,29 +83,29 @@ public class ManagedScoreDocArray : IDisposable
     public static ArrayPool<long> LongArrayPool = ArrayPool<long>.Shared;
     public static ArrayPool<IComparable[]> FieldsArrayPool = ArrayPool<IComparable[]>.Shared;
 
-    // size of a single packed item (int doc + float score) = 8 bytes
+    // Each packed item is one long: int doc (4 bytes) + float score (4 bytes) = 8 bytes.
     private const int SingleItemSize = sizeof(long);
 
-    // 8,192 items * 8 bytes = 64KB. 
-    // we keep a single array under the 85KB LOH threshold.
+    // Max segment size: 8,192 items × 8 bytes = 64KB. Stays under the 85KB LOH threshold.
     private const int MaxItemsPerSegment = 64 * 1024 / SingleItemSize;
 
-    // 128 items * 8 bytes = 1KB
+    // Initial segment size: 128 items × 8 bytes = 1KB. Small enough for top-10/top-100 results.
     private const int InitialItems = 1 * 1024 / SingleItemSize;
 
-    // Log2(8192) = 13
+    // Log2(MaxItemsPerSegment) = Log2(8192) = 13. Used for bit-shift division in the stable phase.
     private const int MaxItemsLog2 = 13;
 
-    // Sequence: 128 -> 256 -> 512 -> 1024 -> 2048 -> 4096
-    // The next one (8192) is the start of stable phase.
-    // Sum = 128 + 256 + ... + 4096 = 8064 items.
+    // Growth phase segment sizes: 128, 256, 512, 1024, 2048, 4096 (6 segments, indices 0–5).
+    // Total items in growth phase = 128 + 256 + 512 + 1024 + 2048 + 4096 = 8,064.
+    // Any global index < 8,064 falls in the growth phase; >= 8,064 falls in the stable phase.
     private const int GrowthPhaseTotalItems = 8064;
 
-    // There are 6 segments in the growth phase (0 to 5)
-    // Segment 6 is the first "Stable" (max Size) segment.
+    // The stable phase begins at segment index 6 (the 7th segment).
+    // Segments 0–5 are growth phase (doubling sizes), segments 6+ are all 8,192 items each.
     private const int StablePhaseSegmentStartIndex = 6;
 
-    // Log2(128) = 7. Used for shifting in growth phase.
+    // Log2(InitialItems) = Log2(128) = 7. Used in the growth phase O(1) index calculation:
+    //   segIndex = Log2((globalIndex >> GrowthPhaseShift) + 1)
     private const int GrowthPhaseShift = 7;
 
     public readonly List<Segment> _segments = new();

--- a/src/Lucene.Net/Util/ManagedScoreDocArray.cs
+++ b/src/Lucene.Net/Util/ManagedScoreDocArray.cs
@@ -40,29 +40,22 @@ public class ManagedScoreDocArray : IDisposable
     private int _currentSegmentCapacity;
 
     private int _length;
-    private IComparable[][] _fields;
-
     public int Length => _length;
-
-    public IComparable[][] Fields => _fields;
 
     public ManagedScoreDocArray()
     {
     }
 
-    public ManagedScoreDocArray(int totalItems, bool fillFields)
+    public ManagedScoreDocArray(int totalItems, bool hasFields)
     {
         _length = totalItems;
-
-        if (fillFields)
-            _fields = new IComparable[totalItems][];
 
         int remainingToAllocate = totalItems;
         int currentSize = InitialItems;
 
         while (_segments.Count < StablePhaseSegmentStartIndex && remainingToAllocate > 0)
         {
-            AllocateSegment(currentSize);
+            AllocateSegment(currentSize, hasFields);
             remainingToAllocate -= currentSize;
             currentSize *= 2;
         }
@@ -73,7 +66,7 @@ public class ManagedScoreDocArray : IDisposable
 
             for (int i = 0; i < stableSegmentsNeeded; i++)
             {
-                AllocateSegment(MaxItemsPerSegment);
+                AllocateSegment(MaxItemsPerSegment, hasFields);
             }
         }
 
@@ -109,18 +102,23 @@ public class ManagedScoreDocArray : IDisposable
         }
     }
 
-    private void AllocateSegment(int size)
+    private void AllocateSegment(int size, bool hasFields)
     {
         var docs = ArrayPool<int>.Shared.Rent(size);
         var scores = ArrayPool<float>.Shared.Rent(size);
 
-        _segments.Add(new Segment
+        var segment = new Segment
         {
             Docs = docs,
             Scores = scores,
             Capacity = size,
             Used = size // default to full, we fix the last one in the constructor
-        });
+        };
+
+        if (hasFields)
+            segment.Fields = ArrayPool<IComparable[]>.Shared.Rent(size);
+
+        _segments.Add(segment);
     }
 
     public void Add(int doc, float score)
@@ -229,6 +227,9 @@ public class ManagedScoreDocArray : IDisposable
         {
             ArrayPool<int>.Shared.Return(seg.Docs);
             ArrayPool<float>.Shared.Return(seg.Scores);
+
+            if (seg.Fields != null)
+                ArrayPool<IComparable[]>.Shared.Return(seg.Fields);
         }
 
         _segments.Clear();
@@ -248,6 +249,7 @@ public class ManagedScoreDocArray : IDisposable
     {
         public int[] Docs;
         public float[] Scores;
+        public IComparable[][] Fields;
         public int Used;
         public int Capacity;
     }
@@ -266,6 +268,7 @@ public class ManagedScoreDocArray : IDisposable
 
         private int[] _currentDocs;
         private float[] _currentScores;
+        private IComparable[][] _currentFields;
 
         private int _segIndex;
         private int _indexInSegment;
@@ -295,10 +298,11 @@ public class ManagedScoreDocArray : IDisposable
             var seg = _parent._segments[_segIndex];
             _currentDocs = seg.Docs;
             _currentScores = seg.Scores;
+            _currentFields = seg.Fields;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(int doc, float score)
+        public void Write(int doc, float score, IComparable[] fields = null)
         {
             if (_parent.Length == 0)
                 ThrowOnEmptyArray();
@@ -314,24 +318,28 @@ public class ManagedScoreDocArray : IDisposable
                 Unsafe.Add(ref docsRef, _indexInSegment) = doc;
                 Unsafe.Add(ref scoresRef, _indexInSegment) = score;
 
+                if (fields != null)
+                {
+                    ref IComparable[] fieldsRef = ref MemoryMarshal.GetArrayDataReference(_currentFields);
+                    Unsafe.Add(ref fieldsRef, _indexInSegment) = fields;
+                }
+
                 _indexInSegment--;
                 return;
             }
 
             // SLOW PATH: we crossed a boundary, switch to previous segment
-            SwitchToPreviousSegment(doc, score);
+            SwitchToPreviousSegment(doc, score, fields);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(int index, (int Doc, float Score, IComparable[] fields) fieldDoc)
         {
-            Write(fieldDoc.Doc, fieldDoc.Score);
-
-            _parent._fields[index] = fieldDoc.fields;
-    }
+            Write(fieldDoc.Doc, fieldDoc.Score, fieldDoc.fields);
+        }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SwitchToPreviousSegment(int doc, float score)
+        private void SwitchToPreviousSegment(int doc, float score, IComparable[] fields = null)
         {
             _segIndex--;
 
@@ -341,11 +349,15 @@ public class ManagedScoreDocArray : IDisposable
             var seg = _parent._segments[_segIndex];
             _currentDocs = seg.Docs;
             _currentScores = seg.Scores;
+            _currentFields = seg.Fields;
 
             _indexInSegment = seg.Capacity - 1;
 
             _currentDocs[_indexInSegment] = doc;
             _currentScores[_indexInSegment] = score;
+
+            if (fields != null)
+                _currentFields[_indexInSegment] = fields;
 
             _indexInSegment--;
         }
@@ -371,6 +383,7 @@ public class ManagedScoreDocArray : IDisposable
         private readonly ManagedScoreDocArray _managedParent;
         private int[] _currentDocs;
         private float[] _currentScores;
+        private IComparable[][] _currentFields;
         private int _currentSegUsedCount;
 
         private int _segIndex;
@@ -398,6 +411,7 @@ public class ManagedScoreDocArray : IDisposable
                 var seg = parent._segments[_segIndex];
                 _currentDocs = seg.Docs;
                 _currentScores = seg.Scores;
+                _currentFields = seg.Fields;
 
                 _currentSegUsedCount = (_segIndex == parent._segments.Count - 1)
                     ? parent._currentSegmentUsed
@@ -407,6 +421,7 @@ public class ManagedScoreDocArray : IDisposable
             {
                 _currentDocs = null;
                 _currentScores = null;
+                _currentFields = null;
                 _currentSegUsedCount = 0;
             }
         }
@@ -462,6 +477,66 @@ public class ManagedScoreDocArray : IDisposable
 
             doc = 0;
             score = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Read(out int doc, out float score, out IComparable[] fields)
+        {
+            // FAST PATH: We are inside the boundaries of the current segment
+            if (_indexInSegment < _currentSegUsedCount)
+            {
+                // OPTIMIZATION: Unsafe ref arithmetic
+                ref int docsStart = ref MemoryMarshal.GetArrayDataReference(_currentDocs);
+                ref float scoresStart = ref MemoryMarshal.GetArrayDataReference(_currentScores);
+                ref IComparable[] fieldsStart = ref MemoryMarshal.GetArrayDataReference(_currentFields);
+
+                doc = Unsafe.Add(ref docsStart, _indexInSegment);
+                score = Unsafe.Add(ref scoresStart, _indexInSegment);
+                fields = Unsafe.Add(ref fieldsStart, _indexInSegment);
+
+                _indexInSegment++;
+                return true;
+            }
+
+            return ReadNextManagedSegment(out doc, out score, out fields);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool ReadNextManagedSegment(out int doc, out float score, out IComparable[] fields)
+        {
+            _segIndex++;
+            _indexInSegment = 0;
+
+            if (_managedParent == null || _segIndex >= _managedParent._segments.Count)
+            {
+                doc = 0;
+                score = 0;
+                fields = null;
+                return false;
+            }
+
+            var seg = _managedParent._segments[_segIndex];
+            _currentDocs = seg.Docs;
+            _currentScores = seg.Scores;
+            _currentFields = seg.Fields;
+
+            _currentSegUsedCount = (_segIndex == _managedParent._segments.Count - 1)
+                ? _managedParent._currentSegmentUsed
+                : seg.Used;
+
+            if (_indexInSegment < _currentSegUsedCount)
+            {
+                doc = _currentDocs[_indexInSegment];
+                score = _currentScores[_indexInSegment];
+                fields = _currentFields[_indexInSegment];
+                _indexInSegment++;
+                return true;
+            }
+
+            doc = 0;
+            score = 0;
+            fields = null;
             return false;
         }
     }

--- a/test/Lucene.Net.Test/Analysis/TestKeywordAnalyzer.cs
+++ b/test/Lucene.Net.Test/Analysis/TestKeywordAnalyzer.cs
@@ -70,9 +70,9 @@ namespace Lucene.Net.Analysis
 			QueryParser queryParser = new QueryParser(Version.LUCENE_CURRENT, "description", analyzer);
 			Query query = queryParser.Parse("partnum:Q36 AND SPACE");
 			
-			ScoreDoc[] hits = searcher.Search(query, null, 1000, null).ScoreDocs;
+			var topDocs = searcher.Search(query, null, 1000, null);
 			Assert.AreEqual("+partnum:Q36 +space", query.ToString("description"), "Q36 kept as-is");
-			Assert.AreEqual(1, hits.Length, "doc found!");
+			Assert.AreEqual(1, topDocs.ScoreDocArray.Length, "doc found!");
 		}
 		
         [Test]

--- a/test/Lucene.Net.Test/Search/JustCompileSearch.cs
+++ b/test/Lucene.Net.Test/Search/JustCompileSearch.cs
@@ -133,7 +133,7 @@ namespace Lucene.Net.Search
 				throw new System.NotSupportedException(Lucene.Net.Search.JustCompileSearch.UNSUPPORTED_MSG);
 			}
 			
-			public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, IState state)
+			public override TopFieldDocs Search(Weight weight, Filter filter, int n, Sort sort, bool fillFields, IState state)
 			{
 				throw new System.NotSupportedException(Lucene.Net.Search.JustCompileSearch.UNSUPPORTED_MSG);
 			}

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using Lucene.Net.Util;
+using NUnit.Framework;
+
+namespace Lucene.Net.Search;
+
+[TestFixture]
+public class ManagedScoreDocArrayTests
+{
+    // ---------------------------------------------------------
+    // 1. Core Logic & Growth Phase Tests
+    // ---------------------------------------------------------
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(256)]          // End of first segment
+    [TestCase(257)]          // Start of second segment
+    [TestCase(16128)]        // End of Growth Phase (Sum of 256..8192)
+    [TestCase(16129)]        // Start of Stable Phase (First 16k segment)
+    [TestCase(50000)]        // Mid-range
+    [TestCase(128000)]       // Target upper bound
+    public void Add_And_Indexer_Work_For_Various_Lengths(int count)
+    {
+        using var array = new ManagedScoreDocArray();
+
+        // Populate
+        for (int i = 0; i < count; i++)
+        {
+            array.Add(i, i * 1.5f);
+        }
+
+        // Verify Length
+        Assert.That(array.Length, Is.EqualTo(count));
+
+        // Verify Random Access Indexer
+        for (int i = 0; i < count; i++)
+        {
+            var (doc, score) = array[i];
+            Assert.That(doc, Is.EqualTo(i));
+            Assert.That(score, Is.EqualTo(i * 1.5f));
+        }
+    }
+
+    [Test]
+    public void Add_Resizes_Correctly_Across_Segments()
+    {
+        // This test focuses on the transition logic of EnsureCapacity
+        using var array = new ManagedScoreDocArray();
+
+        // Fill exactly to the end of the Growth phase
+        int growthLimit = 16128;
+        for (int i = 0; i < growthLimit; i++)
+        {
+            array.Add(i, 0f);
+        }
+
+        // We expect 6 segments (256, 512, 1024, 2048, 4096, 8192)
+        Assert.That(array._segments.Count, Is.EqualTo(6));
+
+        // Add one more to trigger the first Stable segment (16k)
+        array.Add(999, 999f);
+
+        Assert.That(array._segments.Count, Is.EqualTo(7));
+        Assert.That(array._segments[6].Capacity, Is.EqualTo(16384)); // Verify new segment size
+
+        // Verify data integrity across the boundary
+        Assert.That(array[0].Doc, Is.EqualTo(0));
+        Assert.That(array[16128].Doc, Is.EqualTo(999));
+    }
+
+    // ---------------------------------------------------------
+    // 2. ScoreDocReader Tests (Forward Iteration)
+    // ---------------------------------------------------------
+
+    [TestCase(100)]
+    [TestCase(16128)] // Boundary
+    [TestCase(35000)]
+    public void Reader_Iterates_Correctly(int count)
+    {
+        using var array = new ManagedScoreDocArray();
+        for (int i = 0; i < count; i++) array.Add(i, i + 0.5f);
+
+        var reader = array.GetReader(0);
+        int readCount = 0;
+
+        while (reader.Read(out int doc, out float score))
+        {
+            Assert.That(doc, Is.EqualTo(readCount));
+            Assert.That(score, Is.EqualTo(readCount + 0.5f));
+            readCount++;
+        }
+
+        Assert.That(readCount, Is.EqualTo(count));
+    }
+
+    [Test]
+    public void Reader_Can_Start_From_Offset()
+    {
+        int total = 1000;
+        int startOffset = 500;
+        using var array = new ManagedScoreDocArray();
+        for (int i = 0; i < total; i++) array.Add(i, i);
+
+        var reader = array.GetReader(startOffset);
+
+        // Read first item
+        bool success = reader.Read(out int doc, out float score);
+
+        Assert.That(success, Is.True);
+        Assert.That(doc, Is.EqualTo(500));
+    }
+
+    [Test]
+    public void Reader_Handles_Empty_Array()
+    {
+        using var array = new ManagedScoreDocArray();
+        var reader = array.GetReader(0);
+        Assert.That(reader.Read(out _, out _), Is.False);
+    }
+
+    // ---------------------------------------------------------
+    // 3. BackwardsWriter Tests
+    // ---------------------------------------------------------
+
+    [TestCase(256)]           // Single segment full
+    [TestCase(16128)]         // Exact growth phase full
+    [TestCase(16129)]         // Crossed into stable
+    [TestCase(128000)]        // Large scale
+    public void BackwardsWriter_Fills_Array_Correctly(int count)
+    {
+        // 1. Pre-allocate the array size (simulating how a Collector works)
+        using var array = new ManagedScoreDocArray(count, fillFields: false);
+
+        Assert.That(array.Length, Is.EqualTo(count));
+
+        // 2. Get the backwards writer
+        var writer = array.GetBackwardsWriter();
+
+        // 3. Fill backwards (simulating a PriorityQueue pop operation)
+        // We write: index -> docId
+        for (int i = count - 1; i >= 0; i--)
+        {
+            writer.Write(i, i * 2.0f);
+        }
+
+        // 4. Verify using standard forward indexer
+        for (int i = 0; i < count; i++)
+        {
+            var (doc, score) = array[i];
+            Assert.That(doc, Is.EqualTo(i));
+            Assert.That(score, Is.EqualTo(i * 2.0f));
+        }
+    }
+
+    [Test]
+    public void BackwardsWriter_Throws_If_Over_Written()
+    {
+        using var array = new ManagedScoreDocArray(10, false);
+        var writer = array.GetBackwardsWriter();
+
+        // Write valid items
+        for (int i = 0; i < 10; i++) writer.Write(i, 0);
+
+        // Try to write one more (should go below index 0)
+        Assert.Throws<IndexOutOfRangeException>(() => writer.Write(99, 0));
+    }
+
+    // ---------------------------------------------------------
+    // 4. Boundary Stress Test (128k)
+    // ---------------------------------------------------------
+
+    [Test]
+    public void Stress_Test_128000_Items()
+    {
+        const int Target = 128000;
+        using var array = new ManagedScoreDocArray();
+
+        // 1. Add
+        for (int i = 0; i < Target; i++)
+        {
+            array.Add(i, i);
+        }
+
+        // 2. Validate Random Access
+        // Check specific boundaries known in the code:
+        // 256, 16128, 32512 (16128 + 16384)
+        int[] boundaryChecks = { 0, 255, 256, 16127, 16128, 32511, 32512, Target - 1 };
+
+        foreach (var index in boundaryChecks)
+        {
+            Assert.That(array[index].Doc, Is.EqualTo(index), $"Failed at index {index}");
+        }
+
+        // 3. Validate Sequential Read
+        var reader = array.GetReader(0);
+        int count = 0;
+        while (reader.Read(out int d, out float s))
+        {
+            if (count % 10000 == 0) // Spot check to save time
+            {
+                Assert.That(d, Is.EqualTo(count));
+            }
+            count++;
+        }
+        Assert.That(count, Is.EqualTo(Target));
+    }
+
+    // ---------------------------------------------------------
+    // 5. Fields / Auxiliary Data Tests
+    // ---------------------------------------------------------
+
+    [Test]
+    public void Constructor_Allocates_Fields_If_Requested()
+    {
+        int size = 100;
+        using var array = new ManagedScoreDocArray(size, fillFields: true);
+
+        Assert.That(array.Fields, Is.Not.Null);
+        Assert.That(array.Fields.Length, Is.EqualTo(size));
+
+        // Test writing to fields via BackwardsWriter
+        var writer = array.GetBackwardsWriter();
+        var dummyFields = new IComparable[] { "test" };
+
+        // Write at the last index
+        writer.Write(size - 1, (99, 1.0f, dummyFields));
+
+        Assert.That(array.Fields[size - 1], Is.EqualTo(dummyFields));
+        Assert.That(array[size - 1].Doc, Is.EqualTo(99));
+    }
+
+    [Test]
+    public void Dispose_Clears_State()
+    {
+        var array = new ManagedScoreDocArray();
+        array.Add(1, 1);
+
+        array.Dispose();
+
+        Assert.That(array.Length, Is.EqualTo(0));
+        Assert.That(array._segments, Is.Empty);
+
+        // Ensure accessing after dispose throws
+        Assert.Throws<IndexOutOfRangeException>(() => { var _ = array[0]; });
+    }
+
+    [Test]
+    public void Zero_Length_Array_Edge_Cases()
+    {
+        // 1. Setup: Test both the explicit constructor and the default constructor
+        using var arrayExplicit = new ManagedScoreDocArray(0, fillFields: false);
+        using var arrayDefault = new ManagedScoreDocArray();
+
+        // 2. Verify Length property
+        Assert.That(arrayExplicit.Length, Is.EqualTo(0));
+        Assert.That(arrayDefault.Length, Is.EqualTo(0));
+
+        // 3. Verify Indexer: Accessing index 0 should throw
+        Assert.Throws<IndexOutOfRangeException>(() => { var _ = arrayExplicit[0]; });
+
+        // 4. Verify Reader: Should return false immediately
+        var reader = arrayExplicit.GetReader(0);
+        bool hasData = reader.Read(out int doc, out float score);
+
+        Assert.That(hasData, Is.False, "Reader should not find any data in empty array");
+        Assert.That(doc, Is.EqualTo(0), "Out parameter should be default");
+        Assert.That(score, Is.EqualTo(0f), "Out parameter should be default");
+
+        // 5. Verify BackwardsWriter: Writing to an empty array is impossible
+        // The source code throws InvalidOperationException in Write() if Length == 0
+        var writer = arrayExplicit.GetBackwardsWriter();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => writer.Write(1, 1.0f));
+        Assert.That(ex.Message, Does.Contain("empty array"));
+    }
+}

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -212,7 +212,15 @@ public class ManagedScoreDocArrayTests
 
         for (int i = 0; i < 10; i++) writer.Write(i, 0);
 
-        Assert.Throws<IndexOutOfRangeException>(() => writer.Write(99, 0));
+        try
+        {
+            writer.Write(99, 0);
+            Assert.Fail("Expected IndexOutOfRangeException");
+        }
+        catch (IndexOutOfRangeException)
+        {
+            // expected
+        }
     }
 
     // ---------------------------------------------------------
@@ -390,7 +398,15 @@ public class ManagedScoreDocArrayTests
         Assert.That(arrayExplicit.Length, Is.EqualTo(0));
 
         // Indexer
-        Assert.Throws<IndexOutOfRangeException>(() => { var _ = arrayExplicit[0]; });
+        try
+        {
+            var _ = arrayExplicit[0];
+            Assert.Fail("Expected IndexOutOfRangeException");
+        }
+        catch (IndexOutOfRangeException)
+        {
+            // expected
+        }
 
         // Reader
         var reader = arrayExplicit.GetReader(0);
@@ -398,7 +414,14 @@ public class ManagedScoreDocArrayTests
 
         // Writer
         var writer = arrayExplicit.GetBackwardsWriter();
-        var ex = Assert.Throws<InvalidOperationException>(() => writer.Write(1, 1.0f));
-        Assert.That(ex.Message, Does.Contain("empty array"));
+        try
+        {
+            writer.Write(1, 1.0f);
+            Assert.Fail("Expected InvalidOperationException");
+        }
+        catch (InvalidOperationException ex)
+        {
+            Assert.That(ex.Message, Does.Contain("empty array"));
+        }
     }
 }

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -194,12 +194,9 @@ public class ManagedScoreDocArrayTests
         using var array = new ManagedScoreDocArray(3, hasFields: false);
         var writer = array.GetBackwardsWriter();
 
-        // Write index 2
-        writer.Write(2, (Doc: 100, Score: 1.0f, fields: null));
-        // Write index 1
-        writer.Write(1, (Doc: 200, Score: 2.0f, fields: null));
-        // Write index 0
-        writer.Write(0, (Doc: 300, Score: 3.0f, fields: null));
+        writer.Write(100, 1.0f);
+        writer.Write(200, 2.0f);
+        writer.Write(300, 3.0f);
 
         // Verify
         Assert.That(array[0].Doc, Is.EqualTo(300));

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -44,7 +44,6 @@ public class ManagedScoreDocArrayTests
     [Test]
     public void Add_Resizes_Correctly_Across_Segments()
     {
-        // This test focuses on the transition logic of EnsureCapacity
         using var array = new ManagedScoreDocArray();
 
         // Fill exactly to the end of the Growth phase
@@ -54,14 +53,13 @@ public class ManagedScoreDocArrayTests
             array.Add(i, 0f);
         }
 
-        // We expect 6 segments (256, 512, 1024, 2048, 4096, 8192)
         Assert.That(array._segments.Count, Is.EqualTo(6));
 
         // Add one more to trigger the first Stable segment (16k)
         array.Add(999, 999f);
 
         Assert.That(array._segments.Count, Is.EqualTo(7));
-        Assert.That(array._segments[6].Capacity, Is.EqualTo(16384)); // Verify new segment size
+        Assert.That(array._segments[6].Capacity, Is.EqualTo(16384));
 
         // Verify data integrity across the boundary
         Assert.That(array[0].Doc, Is.EqualTo(0));
@@ -69,7 +67,7 @@ public class ManagedScoreDocArrayTests
     }
 
     // ---------------------------------------------------------
-    // 2. ScoreDocReader Tests (Forward Iteration)
+    // 2. ScoreDocReader Tests
     // ---------------------------------------------------------
 
     [TestCase(100)]
@@ -103,7 +101,6 @@ public class ManagedScoreDocArrayTests
 
         var reader = array.GetReader(startOffset);
 
-        // Read first item
         bool success = reader.Read(out int doc, out float score);
 
         Assert.That(success, Is.True);
@@ -119,31 +116,27 @@ public class ManagedScoreDocArrayTests
     }
 
     // ---------------------------------------------------------
-    // 3. BackwardsWriter Tests
+    // 3. BackwardsWriter Tests (Standard & Complex Boundaries)
     // ---------------------------------------------------------
 
-    [TestCase(256)]           // Single segment full
-    [TestCase(16128)]         // Exact growth phase full
-    [TestCase(16129)]         // Crossed into stable
-    [TestCase(128000)]        // Large scale
+    [TestCase(256)]
+    [TestCase(16128)]
+    [TestCase(16129)]
+    [TestCase(128000)]
     public void BackwardsWriter_Fills_Array_Correctly(int count)
     {
-        // 1. Pre-allocate the array size (simulating how a Collector works)
-        using var array = new ManagedScoreDocArray(count, fillFields: false);
-
+        using var array = new ManagedScoreDocArray(count, hasFields: false);
         Assert.That(array.Length, Is.EqualTo(count));
 
-        // 2. Get the backwards writer
         var writer = array.GetBackwardsWriter();
 
-        // 3. Fill backwards (simulating a PriorityQueue pop operation)
-        // We write: index -> docId
+        // Fill backwards
         for (int i = count - 1; i >= 0; i--)
         {
             writer.Write(i, i * 2.0f);
         }
 
-        // 4. Verify using standard forward indexer
+        // Verify using standard indexer
         for (int i = 0; i < count; i++)
         {
             var (doc, score) = array[i];
@@ -153,20 +146,115 @@ public class ManagedScoreDocArrayTests
     }
 
     [Test]
+    public void BackwardsWriter_Crosses_Growth_Segments_Correctly()
+    {
+        // Segment 0 size: 256. 
+        // We allocate 300 items. This spans Segment 0 (256) and Segment 1 (size 512, used 44).
+        int count = 300;
+        using var array = new ManagedScoreDocArray(count, hasFields: false);
+        var writer = array.GetBackwardsWriter();
+
+        for (int i = count - 1; i >= 0; i--)
+        {
+            writer.Write(i, i);
+        }
+
+        // Verify the boundary specifically
+        // Index 255 should be in Segment 0
+        // Index 256 should be in Segment 1
+        Assert.That(array[255].Doc, Is.EqualTo(255));
+        Assert.That(array[256].Doc, Is.EqualTo(256));
+    }
+
+    [Test]
+    public void BackwardsWriter_Crosses_Growth_To_Stable_Boundary()
+    {
+        // Growth phase total: 16128 items.
+        // We allocate 16130 items. 
+        // Index 16128 and 16129 are in the first Stable Segment.
+        // Index 16127 is in the last Growth Segment.
+        int count = 16130;
+        using var array = new ManagedScoreDocArray(count, hasFields: false);
+        var writer = array.GetBackwardsWriter();
+
+        for (int i = count - 1; i >= 0; i--)
+        {
+            writer.Write(i, (float)i);
+        }
+
+        // Verify the specific boundary
+        Assert.That(array[16127].Doc, Is.EqualTo(16127)); // Last of growth
+        Assert.That(array[16128].Doc, Is.EqualTo(16128)); // First of stable
+        Assert.That(array[16129].Doc, Is.EqualTo(16129));
+    }
+
+    [Test]
+    public void BackwardsWriter_Tuple_Overload_Works()
+    {
+        using var array = new ManagedScoreDocArray(3, hasFields: false);
+        var writer = array.GetBackwardsWriter();
+
+        // Write index 2
+        writer.Write(2, (Doc: 100, Score: 1.0f, fields: null));
+        // Write index 1
+        writer.Write(1, (Doc: 200, Score: 2.0f, fields: null));
+        // Write index 0
+        writer.Write(0, (Doc: 300, Score: 3.0f, fields: null));
+
+        // Verify
+        Assert.That(array[0].Doc, Is.EqualTo(300));
+        Assert.That(array[1].Doc, Is.EqualTo(200));
+        Assert.That(array[2].Doc, Is.EqualTo(100));
+    }
+
+    [Test]
     public void BackwardsWriter_Throws_If_Over_Written()
     {
         using var array = new ManagedScoreDocArray(10, false);
         var writer = array.GetBackwardsWriter();
 
-        // Write valid items
         for (int i = 0; i < 10; i++) writer.Write(i, 0);
 
-        // Try to write one more (should go below index 0)
         Assert.Throws<IndexOutOfRangeException>(() => writer.Write(99, 0));
     }
 
     // ---------------------------------------------------------
-    // 4. Boundary Stress Test (128k)
+    // 4. Fields / Auxiliary Data Tests 
+    // ---------------------------------------------------------
+
+    [Test]
+    public void End_To_End_Fields_Read_Write()
+    {
+        int size = 300; // Large enough to cross the first segment boundary (256)
+
+        using var array = new ManagedScoreDocArray(size, hasFields: true);
+        var writer = array.GetBackwardsWriter();
+
+        for (int i = size - 1; i >= 0; i--)
+        {
+            var dummyFields = new IComparable[] { $"val_{i}", i };
+            writer.Write(doc: i, score: i * 1.0f, fields: dummyFields);
+        }
+
+        var reader = array.GetReader(0);
+        int readCount = 0;
+
+        while (reader.Read(out int doc, out float score, out IComparable[] fields))
+        {
+            Assert.That(doc, Is.EqualTo(readCount));
+            Assert.That(fields, Is.Not.Null);
+            Assert.That(fields.Length, Is.EqualTo(2));
+            Assert.That(fields[0], Is.EqualTo($"val_{readCount}"));
+            Assert.That(fields[1], Is.EqualTo(readCount));
+
+            readCount++;
+        }
+
+        Assert.That(readCount, Is.EqualTo(size));
+    }
+
+    // ---------------------------------------------------------
+    // 5. Stress & Integrity Tests
     // ---------------------------------------------------------
 
     [Test]
@@ -175,15 +263,12 @@ public class ManagedScoreDocArrayTests
         const int Target = 128000;
         using var array = new ManagedScoreDocArray();
 
-        // 1. Add
         for (int i = 0; i < Target; i++)
         {
             array.Add(i, i);
         }
 
-        // 2. Validate Random Access
-        // Check specific boundaries known in the code:
-        // 256, 16128, 32512 (16128 + 16384)
+        // Validate Random Access at known boundaries
         int[] boundaryChecks = { 0, 255, 256, 16127, 16128, 32511, 32512, Target - 1 };
 
         foreach (var index in boundaryChecks)
@@ -191,12 +276,12 @@ public class ManagedScoreDocArrayTests
             Assert.That(array[index].Doc, Is.EqualTo(index), $"Failed at index {index}");
         }
 
-        // 3. Validate Sequential Read
+        // Validate Sequential Read
         var reader = array.GetReader(0);
         int count = 0;
         while (reader.Read(out int d, out float s))
         {
-            if (count % 10000 == 0) // Spot check to save time
+            if (count % 10000 == 0)
             {
                 Assert.That(d, Is.EqualTo(count));
             }
@@ -205,71 +290,67 @@ public class ManagedScoreDocArrayTests
         Assert.That(count, Is.EqualTo(Target));
     }
 
-    // ---------------------------------------------------------
-    // 5. Fields / Auxiliary Data Tests
-    // ---------------------------------------------------------
-
     [Test]
-    public void Constructor_Allocates_Fields_If_Requested()
+    public void Data_Integrity_Random_Vs_Sequential()
     {
-        int size = 100;
-        using var array = new ManagedScoreDocArray(size, fillFields: true);
+        // This test ensures that iterating via Reader yields the exact same data
+        // as accessing via the Random Access Indexer.
+        int count = 5000;
+        using var array = new ManagedScoreDocArray();
 
-        Assert.That(array.Fields, Is.Not.Null);
-        Assert.That(array.Fields.Length, Is.EqualTo(size));
+        // Populate with pseudo-random data
+        for (int i = 0; i < count; i++)
+        {
+            array.Add(i * 2, i * 0.33f);
+        }
 
-        // Test writing to fields via BackwardsWriter
-        var writer = array.GetBackwardsWriter();
-        var dummyFields = new IComparable[] { "test" };
+        var reader = array.GetReader(0);
+        int idx = 0;
 
-        // Write at the last index
-        writer.Write(size - 1, (99, 1.0f, dummyFields));
+        while (reader.Read(out int rDoc, out float rScore))
+        {
+            var (iDoc, iScore) = array[idx];
 
-        Assert.That(array.Fields[size - 1], Is.EqualTo(dummyFields));
-        Assert.That(array[size - 1].Doc, Is.EqualTo(99));
+            Assert.That(rDoc, Is.EqualTo(iDoc), $"Doc Mismatch at {idx}");
+            Assert.That(rScore, Is.EqualTo(iScore), $"Score Mismatch at {idx}");
+
+            idx++;
+        }
     }
+
+    // ---------------------------------------------------------
+    // 6. Cleanup & Edge Cases
+    // ---------------------------------------------------------
 
     [Test]
     public void Dispose_Clears_State()
     {
         var array = new ManagedScoreDocArray();
         array.Add(1, 1);
-
         array.Dispose();
 
         Assert.That(array.Length, Is.EqualTo(0));
         Assert.That(array._segments, Is.Empty);
-
-        // Ensure accessing after dispose throws
         Assert.Throws<IndexOutOfRangeException>(() => { var _ = array[0]; });
     }
 
     [Test]
     public void Zero_Length_Array_Edge_Cases()
     {
-        // 1. Setup: Test both the explicit constructor and the default constructor
-        using var arrayExplicit = new ManagedScoreDocArray(0, fillFields: false);
-        using var arrayDefault = new ManagedScoreDocArray();
+        using var arrayExplicit = new ManagedScoreDocArray(0, hasFields: false);
 
-        // 2. Verify Length property
+        // Length
         Assert.That(arrayExplicit.Length, Is.EqualTo(0));
-        Assert.That(arrayDefault.Length, Is.EqualTo(0));
 
-        // 3. Verify Indexer: Accessing index 0 should throw
+        // Indexer
         Assert.Throws<IndexOutOfRangeException>(() => { var _ = arrayExplicit[0]; });
 
-        // 4. Verify Reader: Should return false immediately
+        // Reader
         var reader = arrayExplicit.GetReader(0);
-        bool hasData = reader.Read(out int doc, out float score);
+        Assert.That(reader.Read(out _, out _), Is.False);
 
-        Assert.That(hasData, Is.False, "Reader should not find any data in empty array");
-        Assert.That(doc, Is.EqualTo(0), "Out parameter should be default");
-        Assert.That(score, Is.EqualTo(0f), "Out parameter should be default");
-
-        // 5. Verify BackwardsWriter: Writing to an empty array is impossible
-        // The source code throws InvalidOperationException in Write() if Length == 0
+        // Writer
         var writer = arrayExplicit.GetBackwardsWriter();
-
         var ex = Assert.Throws<InvalidOperationException>(() => writer.Write(1, 1.0f));
         Assert.That(ex.Message, Does.Contain("empty array"));
     }

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -53,13 +53,13 @@ public class ManagedScoreDocArrayTests
             array.Add(i, 0f);
         }
 
-        Assert.That(array._segments.Count, Is.EqualTo(6));
+        Assert.That(array._segments.Count, Is.EqualTo(7));
 
         // Add one more to trigger the first Stable segment (16k)
         array.Add(999, 999f);
 
         Assert.That(array._segments.Count, Is.EqualTo(7));
-        Assert.That(array._segments[6].Capacity, Is.EqualTo(16384));
+        Assert.That(array._segments[6].Capacity, Is.EqualTo(8192));
 
         // Verify data integrity across the boundary
         Assert.That(array[0].Doc, Is.EqualTo(0));

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -259,6 +259,17 @@ public class ManagedScoreDocArrayTests
         }
 
         Assert.That(readCount, Is.EqualTo(size));
+
+        reader = array.GetReader(0);
+        readCount = 0;
+
+        while (reader.Read(out int doc, out float score))
+        {
+            Assert.That(doc, Is.EqualTo(readCount));
+            readCount++;
+        }
+
+        Assert.That(readCount, Is.EqualTo(size));
     }
 
     // ---------------------------------------------------------

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -13,10 +13,10 @@ public class ManagedScoreDocArrayTests
 
     [TestCase(0)]
     [TestCase(1)]
-    [TestCase(256)]          // End of first segment
-    [TestCase(257)]          // Start of second segment
-    [TestCase(16128)]        // End of Growth Phase (Sum of 256..8192)
-    [TestCase(16129)]        // Start of Stable Phase (First 16k segment)
+    [TestCase(128)]          // End of first segment (Segment 0 = 128 items)
+    [TestCase(129)]          // Start of second segment
+    [TestCase(8064)]         // End of Growth Phase (Sum of 128+256+512+1024+2048+4096)
+    [TestCase(8065)]         // Start of Stable Phase (First 8192-item segment)
     [TestCase(50000)]        // Mid-range
     [TestCase(128000)]       // Target upper bound
     public void Add_And_Indexer_Work_For_Various_Lengths(int count)
@@ -47,23 +47,26 @@ public class ManagedScoreDocArrayTests
         using var array = new ManagedScoreDocArray();
 
         // Fill exactly to the end of the Growth phase
-        int growthLimit = 16128;
+        // Growth segments: 128 + 256 + 512 + 1024 + 2048 + 4096 = 8064
+        int growthLimit = 8064;
         for (int i = 0; i < growthLimit; i++)
         {
             array.Add(i, 0f);
         }
 
-        Assert.That(array._segments.Count, Is.EqualTo(7));
+        // 6 growth segments (indices 0–5)
+        Assert.That(array.SegmentCount, Is.EqualTo(6));
 
-        // Add one more to trigger the first Stable segment (16k)
+        // Add one more to trigger the first Stable segment (8192 items)
         array.Add(999, 999f);
 
-        Assert.That(array._segments.Count, Is.EqualTo(7));
-        Assert.That(array._segments[6].Capacity, Is.EqualTo(8192));
+        // Now we have 7 segments: 6 growth + 1 stable
+        Assert.That(array.SegmentCount, Is.EqualTo(7));
+        Assert.That(array.SegmentCapacity(6), Is.EqualTo(8192));
 
         // Verify data integrity across the boundary
         Assert.That(array[0].Doc, Is.EqualTo(0));
-        Assert.That(array[16128].Doc, Is.EqualTo(999));
+        Assert.That(array[8064].Doc, Is.EqualTo(999));
     }
 
     // ---------------------------------------------------------
@@ -71,7 +74,7 @@ public class ManagedScoreDocArrayTests
     // ---------------------------------------------------------
 
     [TestCase(100)]
-    [TestCase(16128)] // Boundary
+    [TestCase(8064)]  // Growth phase boundary
     [TestCase(35000)]
     public void Reader_Iterates_Correctly(int count)
     {
@@ -120,8 +123,8 @@ public class ManagedScoreDocArrayTests
     // ---------------------------------------------------------
 
     [TestCase(256)]
-    [TestCase(16128)]
-    [TestCase(16129)]
+    [TestCase(8064)]
+    [TestCase(8065)]
     [TestCase(128000)]
     public void BackwardsWriter_Fills_Array_Correctly(int count)
     {
@@ -148,9 +151,9 @@ public class ManagedScoreDocArrayTests
     [Test]
     public void BackwardsWriter_Crosses_Growth_Segments_Correctly()
     {
-        // Segment 0 size: 256. 
-        // We allocate 300 items. This spans Segment 0 (256) and Segment 1 (size 512, used 44).
-        int count = 300;
+        // Segment 0 size: 128, Segment 1 size: 256.
+        // We allocate 200 items. This spans Segment 0 (128) and Segment 1 (size 256, used 72).
+        int count = 200;
         using var array = new ManagedScoreDocArray(count, hasFields: false);
         var writer = array.GetBackwardsWriter();
 
@@ -160,20 +163,20 @@ public class ManagedScoreDocArrayTests
         }
 
         // Verify the boundary specifically
-        // Index 255 should be in Segment 0
-        // Index 256 should be in Segment 1
-        Assert.That(array[255].Doc, Is.EqualTo(255));
-        Assert.That(array[256].Doc, Is.EqualTo(256));
+        // Index 127 should be in Segment 0
+        // Index 128 should be in Segment 1
+        Assert.That(array[127].Doc, Is.EqualTo(127));
+        Assert.That(array[128].Doc, Is.EqualTo(128));
     }
 
     [Test]
     public void BackwardsWriter_Crosses_Growth_To_Stable_Boundary()
     {
-        // Growth phase total: 16128 items.
-        // We allocate 16130 items. 
-        // Index 16128 and 16129 are in the first Stable Segment.
-        // Index 16127 is in the last Growth Segment.
-        int count = 16130;
+        // Growth phase total: 8064 items (segments 0–5).
+        // We allocate 8066 items. 
+        // Index 8064 and 8065 are in the first Stable Segment (segment 6).
+        // Index 8063 is in the last Growth Segment (segment 5).
+        int count = 8066;
         using var array = new ManagedScoreDocArray(count, hasFields: false);
         var writer = array.GetBackwardsWriter();
 
@@ -183,9 +186,9 @@ public class ManagedScoreDocArrayTests
         }
 
         // Verify the specific boundary
-        Assert.That(array[16127].Doc, Is.EqualTo(16127)); // Last of growth
-        Assert.That(array[16128].Doc, Is.EqualTo(16128)); // First of stable
-        Assert.That(array[16129].Doc, Is.EqualTo(16129));
+        Assert.That(array[8063].Doc, Is.EqualTo(8063)); // Last of growth
+        Assert.That(array[8064].Doc, Is.EqualTo(8064)); // First of stable
+        Assert.That(array[8065].Doc, Is.EqualTo(8065));
     }
 
     [Test]
@@ -274,7 +277,8 @@ public class ManagedScoreDocArrayTests
         }
 
         // Validate Random Access at known boundaries
-        int[] boundaryChecks = { 0, 255, 256, 16127, 16128, 32511, 32512, Target - 1 };
+        // Growth phase: [0..8063], Stable segments: [8064..16255], [16256..24447], ...
+        int[] boundaryChecks = { 0, 127, 128, 8063, 8064, 16255, 16256, Target - 1 };
 
         foreach (var index in boundaryChecks)
         {
@@ -385,7 +389,7 @@ public class ManagedScoreDocArrayTests
         array.Dispose();
 
         Assert.That(array.Length, Is.EqualTo(0));
-        Assert.That(array._segments, Is.Empty);
+        Assert.AreEqual(0, array.SegmentCount);
         Assert.Throws<IndexOutOfRangeException>(() => { var _ = array[0]; });
     }
 

--- a/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
+++ b/test/Lucene.Net.Test/Search/ManagedScoreDocArrayTests.cs
@@ -315,6 +315,56 @@ public class ManagedScoreDocArrayTests
         }
     }
 
+    [Test]
+    public void Fields_With_Multiple_Sort_Criteria_Persist_Correctly()
+    {
+        // Arrange
+        // Use enough items to cross the first segment boundary (256 items) to ensure 
+        // the parallel field arrays are managed correctly across segments.
+        int count = 300;
+        using var array = new ManagedScoreDocArray(count, hasFields: true);
+        var writer = array.GetBackwardsWriter();
+
+        // Act: Write data backwards (typical TopDocs collector behavior)
+        for (int i = count - 1; i >= 0; i--)
+        {
+            // Simulate 3 sort fields:
+            // 0: String (e.g., Category)
+            // 1: Int (e.g., Price - creating a descending sort simulation)
+            // 2: Float (e.g., Relevance/Score)
+            var multiFields = new IComparable[]
+            {
+                $"Category_{i % 10}", // String
+                i * 100,              // Int
+                (float)i / 0.5f       // Float
+            };
+
+            writer.Write(i, i * 1.0f, multiFields);
+        }
+
+        // Assert: Read forwards
+        var reader = array.GetReader(0);
+        int readCount = 0;
+
+        while (reader.Read(out int doc, out float score, out IComparable[] fields))
+        {
+            Assert.That(doc, Is.EqualTo(readCount));
+
+            // Verify structure
+            Assert.That(fields, Is.Not.Null);
+            Assert.That(fields.Length, Is.EqualTo(3), "Should hold exactly 3 field values");
+
+            // Verify specific values for all 3 fields
+            Assert.That(fields[0], Is.EqualTo($"Category_{readCount % 10}"));
+            Assert.That(fields[1], Is.EqualTo(readCount * 100));
+            Assert.That(fields[2], Is.EqualTo((float)readCount / 0.5f));
+
+            readCount++;
+        }
+
+        Assert.That(readCount, Is.EqualTo(count));
+    }
+
     // ---------------------------------------------------------
     // 6. Cleanup & Edge Cases
     // ---------------------------------------------------------

--- a/test/Lucene.Net.Test/Search/TestTopDocsCollector.cs
+++ b/test/Lucene.Net.Test/Search/TestTopDocsCollector.cs
@@ -17,6 +17,7 @@
 
 using System;
 using Lucene.Net.Store;
+using Lucene.Net.Util;
 using NUnit.Framework;
 
 using KeywordAnalyzer = Lucene.Net.Analysis.KeywordAnalyzer;
@@ -45,9 +46,9 @@ namespace Lucene.Net.Search
 			{
 			}
 			
-			public /*protected internal*/ override TopDocs NewTopDocs(ScoreDoc[] results, int start)
+			public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 			{
-				if (results == null)
+				if (scoreDocArray == null)
 				{
 					return EMPTY_TOPDOCS;
 				}
@@ -55,7 +56,7 @@ namespace Lucene.Net.Search
 				float maxScore = System.Single.NaN;
 				if (start == 0)
 				{
-					maxScore = results[0].Score;
+					maxScore = scoreDocArray[0].Score;
 				}
 				else
 				{
@@ -66,7 +67,7 @@ namespace Lucene.Net.Search
 					maxScore = pq.Pop().Score;
 				}
 				
-				return new TopDocs(internalTotalHits, results, maxScore);
+				return new TopDocs(internalTotalHits, maxScore, scoreDocArray);
 			}
 			
 			public override void  Collect(int doc, IState state)

--- a/test/Lucene.Net.Test/Search/TestTopDocsCollector.cs
+++ b/test/Lucene.Net.Test/Search/TestTopDocsCollector.cs
@@ -46,7 +46,7 @@ namespace Lucene.Net.Search
 			{
 			}
 			
-			public /*protected internal*/ override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
+			public override TopDocs NewTopDocs(ManagedScoreDocArray scoreDocArray, int start)
 			{
 				if (scoreDocArray == null)
 				{

--- a/test/contrib/Lucene.Net.Contrib.Spatial.Tests/Compatibility/FixedBitSetTest.cs
+++ b/test/contrib/Lucene.Net.Contrib.Spatial.Tests/Compatibility/FixedBitSetTest.cs
@@ -104,7 +104,7 @@ namespace Lucene.Net.Contrib.Spatial.Test.Compatibility
 
             TopDocs topDocs = indexSearcher.Search(booleanQuery, 10, null);
 
-            Assert.GreaterOrEqual(topDocs.ScoreDocs.Length, 1); //Search area is centered on a doc so at least one doc should be returned
+            Assert.GreaterOrEqual(topDocs.ScoreDocArray.Length, 1); //Search area is centered on a doc so at least one doc should be returned
         }
 
 


### PR DESCRIPTION
**Replace ScoreDoc[] with Zero-Allocation ManagedScoreDocArray**

**The Problem**
In high-scale search scenarios returning large result sets (e.g., millions of hits), the legacy `ScoreDoc[]` implementation creates significant memory and GC bottlenecks:

1.  **Excessive Memory Overhead:**
      * Each `ScoreDoc` is a class, incurring a 24-byte heap overhead per result.
      * Combined with the array pointer, each hit costs **32 bytes**.
      * *Example:* 10 million hits $\approx$ **320 MB** of active heap memory.
2.  **LOH Fragmentation:**
      * The `ScoreDoc[]` array itself exceeds the 85KB Large Object Heap (LOH) threshold for any result set \> 10,600 items. This causes heap fragmentation and expensive Gen 2 collections.
3.  **GC Pressure & Latency:**
      * Allocating millions of tiny, short-lived `ScoreDoc` objects floods Gen 0/Gen 1, forcing frequent Garbage Collection cycles.
      * Creates a very large reference graph which increases the GC time (https://issues.hibernatingrhinos.com/issue/RavenDB-24815/Large-reference-graph-for-arrays-of-strings).
4.  **Poor Data Locality:**
      * `ScoreDoc[]` is an array of pointers. Iterating it requires "pointer chasing" (jumping to random heap locations), which destroys CPU cache efficiency.

**The Solution: ManagedScoreDocArray**
Replaced the array of objects with a struct-of-arrays pattern (`int[] docs`, `float[] scores`) managed via `ArrayPool`.

1.  **4x Memory Reduction:**
      * We now store only raw primitives: 4 bytes (`int`) + 4 bytes (`float`) = **8 bytes per hit**.
      * *Example:* 10 million hits $\approx$ **80 MB** (down from 320 MB).
2.  **Zero-Allocation & LOH Avoidance:**
      * Buffers are rented from `ArrayPool<T>`, eliminating allocation churn.
      * Internal segments are capped at 64KB, ensuring they **never** enter the LOH.
3.  **Cache-Friendly:**
      * Data is stored contiguously. Scans and sorts benefit from CPU prefetching and SIMD optimizations.

The `TopDocs` class retains the `ScoreDoc[]` property but marks it as `[Obsolete]`. Accessing it will lazily materialize the old array format for compatibility which is only used in tests, but the internal engine uses the efficient `ManagedScoreDocArray`.

Comparison of the peak working set during the execution of the tests.
| Implementation | Peak Working Set | Reduction vs Old |
| :--- | :--- | :--- |
| **Baseline** | 3.967 GB | - |
| 🏆 **ArrayPool** | **920 MB** | **~4.3x less** |

What does this "Memory Reduction" actually mean?  We are specifically talking about the managed memory allocated during the execution of array read and write operations.
In the old implementation, these hot paths generated a massive amount of short-lived objects. Even though most of these allocations were trapped in Gen 0, the Garbage Collector (GC) still had to constantly burn CPU cycles to track and clean them up.

The following benchmarks compare the previous approach (using a List materialized to an array) against the new approach. Both tests were conducted after a warmup phase. In the legacy implementation, this ensured the list returned to the object pool for reuse; the new implementation utilizes ArrayPool. Note that the reported **execution time** is **per request**, while the **allocation** represents the **total memory allocated** throughout the entire process.

* **Peak Speedup**: The highest speedup occurs at maximum load (131k docs, 32 tasks), where the new system is nearly **38x faster**.
* **Peak Efficiency**: Memory reduction is most dramatic in larger datasets, consistently reducing allocations by **500x to 700x**.
* **Scaling**: As the number of tasks increases, the performance gap widens significantly in favor of the new system.

| Docs | Tasks | Old Time (ms) | New Time (ms) | Speedup | Old Alloc | New Alloc | Memory Reduction |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 128 | 1 | 0.00240 | 0.00117 | **2.1x** | 515 KB | 22 KB | **23x** |
| 128 | 4 | 0.00163 | 0.00069 | **2.4x** | 2.01 MB | 88 KB | **23x** |
| 128 | 8 | 0.00112 | 0.00067 | **1.7x** | 4.02 MB | 176 KB | **23x** |
| 1,024 | 1 | 0.00184 | 0.00056 | **3.3x** | 4.02 MB | 51.07 KB | **81x** |
| 16,384 | 4 | 0.00067 | 0.00018 | **3.7x** | 257.18 MB | 608.33 KB | **433x** |
| 16,384 | 8 | 0.00169 | 0.00030 | **5.6x** | 513.20 MB | 1.16 MB | **442x** |
| 16,384 | 16 | 0.00101 | 0.00008 | **12.6x** | 1.00 GB | 1.93 MB | **531x** |
| 16,384 | 32 | 0.00091 | 0.00007 | **13.0x** | 2.00 GB | 2.99 MB | **685x** |
| 131,072 | 1 | 0.00241 | 0.00038 | **6.3x** | 512.00 MB | 255.14 KB | **2,055x** |
| 131,072 | 4 | 0.00125 | 0.00013 | **9.6x** | 2.00 GB | 1.12 MB | **1,829x** |
| 131,072 | 8 | 0.00116 | 0.00010 | **11.6x** | 4.01 GB | 2.05 MB | **2,003x** |
| 131,072 | 16 | 0.00108 | 0.00006 | **18.0x** | 8.02 GB | 10.05 MB | **817x** |
| 131,072 | 32 | 0.00106 | 0.00006 | **17.7x** | 16.03 GB | 8.86 MB | **1,853x** |
