### PR TITLE
RavenDB-25514 - Remove failed entry from cache on generation error to allow retry

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.0.60013</Version>
-    <FileVersion>3.0.60013</FileVersion>
+    <Version>3.0.60014</Version>
+    <FileVersion>3.0.60014</FileVersion>
     <LangVersion>12.0</LangVersion>
     <DebugType>embedded</DebugType>
 

--- a/src/Lucene.Net/Index/ArrayHolder.cs
+++ b/src/Lucene.Net/Index/ArrayHolder.cs
@@ -52,11 +52,12 @@ namespace Lucene.Net.Index
         {
             var indexEnum = new SegmentTermEnum(directory.OpenInput(name, readBufferSize, state), fieldInfos, true, state);
 
+            ArrayHolder holder = null;
+
             try
             {
                 int indexSize = 1 + ((int)indexEnum.size - 1) / indexDivisor; // otherwise read index
-
-                var holder = new ArrayHolder(indexSize, directory, name, fieldInfos);
+                holder = new ArrayHolder(indexSize, directory, name, fieldInfos);
 
                 for (int i = 0; indexEnum.Next(state); i++)
                 {
@@ -76,9 +77,14 @@ namespace Lucene.Net.Index
                 return holder;
 
             }
+            catch
+            {
+                // although we have finalizers, we can release the resources earlier
+                holder?.Dispose();
+                throw;
+            }
             finally
             {
-
                 indexEnum?.Close();
             }
         }

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -221,7 +221,16 @@ namespace Lucene.Net.Search
                     {
                         if (progress.IsValueCreated == false)
                         {
-                            innerCache[key] = progress.Value;
+                            try
+                            {
+                                innerCache[key] = progress.Value;
+                            }
+                            catch
+                            {
+                                // remove the failed entry from cache so next call can retry
+                                innerCache.TryRemove(key, out _);
+                                throw;
+                            }
 
                             // Only check if key.custom (the parser) is
                             // non-null; else, we check twice for a single

--- a/src/Lucene.Net/Search/FieldCacheImpl.cs
+++ b/src/Lucene.Net/Search/FieldCacheImpl.cs
@@ -228,6 +228,19 @@ namespace Lucene.Net.Search
                             catch
                             {
                                 // remove the failed entry from cache so next call can retry
+
+                                // The code's internal mechanism can be a bit misleading.
+                                //
+                                // The definition of the inner cache is `ConcurrentDictionary<Entry, object>`.
+                                //
+                                // 1. Insertion: We first insert the un-materialized `Lazy<T>` object.
+                                //
+                                // 2. Materialization (Replacement): After a successful call to `Lazy<T>.Value` (which executes `CreateValue`), 
+                                //    we attempt to replace the placeholder in the dictionary with the fully materialized value (`T`).
+                                //
+                                // 3. Subsequent Access: The next call will then directly retrieve and use the materialized `T`, 
+                                //    bypassing the `Lazy<T>` logic entirely.
+
                                 innerCache.TryRemove(key, out _);
                                 throw;
                             }

--- a/src/Lucene.Net/Store/Directory.cs
+++ b/src/Lucene.Net/Store/Directory.cs
@@ -115,7 +115,16 @@ namespace Lucene.Net.Store
             var lazyArrayHolder = _termsIndexCachePerSegment.GetOrAdd(name,
                 new Lazy<ArrayHolder>(() => ArrayHolder.GenerateArrayHolder(directory, name, fieldInfos, readBufferSize, indexDivisor, state)));
 
-            return lazyArrayHolder.Value;
+            try
+            {
+                return lazyArrayHolder.Value;
+            }
+            catch
+            {
+                // remove the failed entry from cache so next call can retry
+                _termsIndexCachePerSegment.TryRemove(name, out _);
+                throw;
+            }
         }
 
         public virtual void RemoveFromTermsIndexCache(string name)
@@ -162,7 +171,14 @@ namespace Lucene.Net.Store
         {
             foreach ((_, Lazy<ArrayHolder> cacheLazy) in _termsIndexCachePerSegment)
             {
-                cacheLazy.Value.Dispose();
+                try
+                {
+                    cacheLazy.Value.Dispose();
+                }
+                catch
+                {
+                    // noop
+                }
             }
         }
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-25514/Retry-logic-for-failed-LazyT-cache-computations-is-missing